### PR TITLE
copy all http request headers to outbound request

### DIFF
--- a/src/main/groovy/co/freeside/betamax/proxy/handler/TargetConnector.groovy
+++ b/src/main/groovy/co/freeside/betamax/proxy/handler/TargetConnector.groovy
@@ -40,7 +40,7 @@ class TargetConnector implements HttpHandler {
 
 	private HttpRequest createOutboundRequest(Request request) {
 		def outboundRequest = httpRequestFactory.newHttpRequest(request.method, request.uri.toString())
-		request.headers.every { name, value ->
+		request.headers.each { name, value ->
 			outboundRequest.addHeader(name, value)
 		}
 		outboundRequest.addHeader(VIA, VIA_HEADER)

--- a/src/test/groovy/co/freeside/betamax/proxy/handler/TargetConnectorSpec.groovy
+++ b/src/test/groovy/co/freeside/betamax/proxy/handler/TargetConnectorSpec.groovy
@@ -62,7 +62,7 @@ class TargetConnectorSpec extends Specification {
 
 		then:
 		1 * httpClient.execute(_, _) >> { httpHost, outboundRequest ->
-			request.headers.every { name, value ->
+			request.headers.each { name, value ->
 				assert outboundRequest.getFirstHeader(name).value == value
 			}
 			okResponse


### PR DESCRIPTION
Hi,

TargetConnector is copying only the first HTTP header in the client request to outbound connection. I found out this issue while recording web service calls.

Please merge if it is fine.

Regards,
Sandeep 
