### PR TITLE
Explicitly define propertyUtils in TapeRepresenter

### DIFF
--- a/src/main/groovy/co/freeside/betamax/tape/yaml/TapeRepresenter.groovy
+++ b/src/main/groovy/co/freeside/betamax/tape/yaml/TapeRepresenter.groovy
@@ -29,7 +29,7 @@ import static org.yaml.snakeyaml.nodes.Tag.*
 class TapeRepresenter extends GroovyRepresenter {
 
 	TapeRepresenter() {
-		propertyUtils = new TapePropertyUtils()
+		def propertyUtils = new TapePropertyUtils()
 		representers[URI] = new RepresentURI()
 	}
 


### PR DESCRIPTION
When trying to run tests from within IntelliJ, I hit the following error:

`groovy.lang.MissingPropertyException: No such property: propertyUtils for class: co.freeside.betamax.tape.yaml.TapeRepresenter`

Per http://undefined.com/ia/2008/03/17/groovy-no-such-property-x-for-class-y/, seems we need to explicitly declare `propertyUtils` as a member of the `TapeRepresenter` class. 

There may be more cases were similar edits need to be made. 
