### PR TITLE
Removing TapeMode.DEFAULT since it doesn't really have a purpose, and defaulting to TapeMode.READ_ONLY instead.

### DIFF
--- a/betamax-core/src/main/groovy/co/freeside/betamax/Betamax.java
+++ b/betamax-core/src/main/groovy/co/freeside/betamax/Betamax.java
@@ -17,7 +17,7 @@ package co.freeside.betamax;
 
 import java.lang.annotation.*;
 import static co.freeside.betamax.MatchRule.*;
-import static co.freeside.betamax.TapeMode.DEFAULT;
+import static co.freeside.betamax.TapeMode.READ_ONLY;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -25,6 +25,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 public @interface Betamax {
 	String tape();
-	TapeMode mode() default DEFAULT;
+	TapeMode mode() default READ_ONLY;
 	MatchRule[] match() default {method, uri};
 }

--- a/betamax-core/src/main/groovy/co/freeside/betamax/TapeMode.java
+++ b/betamax-core/src/main/groovy/co/freeside/betamax/TapeMode.java
@@ -21,8 +21,7 @@ public enum TapeMode {
 	READ_ONLY(true, false, false),
 	READ_SEQUENTIAL(true, false, true),
 	WRITE_ONLY(false, true, false),
-	WRITE_SEQUENTIAL(false, true, true),
-	DEFAULT(false, false, false);
+	WRITE_SEQUENTIAL(false, true, true);
 
     private final boolean readable;
     private final boolean writable;

--- a/betamax-core/src/test/groovy/co/freeside/betamax/tape/MultiThreadedTapeWritingSpec.groovy
+++ b/betamax-core/src/test/groovy/co/freeside/betamax/tape/MultiThreadedTapeWritingSpec.groovy
@@ -24,7 +24,7 @@ class MultiThreadedTapeWritingSpec extends Specification {
 		endpoint.start(HelloHandler)
 	}
 
-	@Betamax(tape = 'multi_threaded_tape_writing_spec')
+	@Betamax(tape = 'multi_threaded_tape_writing_spec', mode = TapeMode.READ_WRITE)
 	void 'the tape can cope with concurrent reading and writing'() {
 		when: 'requests are fired concurrently'
 		def finished = new CountDownLatch(threads)

--- a/betamax-httpclient/src/test/groovy/co/freeside/betamax/httpclient/BetamaxHttpClientSpec.groovy
+++ b/betamax-httpclient/src/test/groovy/co/freeside/betamax/httpclient/BetamaxHttpClientSpec.groovy
@@ -27,7 +27,7 @@ class BetamaxHttpClientSpec extends Specification {
 	@AutoCleanup('stop') SimpleServer endpoint = new SimpleServer()
 	def http = new BetamaxHttpClient(recorder)
 
-	@Betamax(tape = 'betamax http client')
+	@Betamax(tape = 'betamax http client', mode = TapeMode.READ_WRITE)
 	void 'can use Betamax without starting the proxy'() {
 		given:
 		endpoint.start(HelloHandler)
@@ -47,7 +47,7 @@ class BetamaxHttpClientSpec extends Specification {
 		response.getFirstHeader('X-Betamax').value == 'REC'
 	}
 
-	@Betamax(tape = 'betamax http client')
+	@Betamax(tape = 'betamax http client', mode = TapeMode.READ_WRITE)
 	void 'can play back from tape'() {
 		given:
 		def handler = Mock(Handler)
@@ -71,7 +71,7 @@ class BetamaxHttpClientSpec extends Specification {
 		0 * handler.handle(*_)
 	}
 
-	@Betamax(tape = 'betamax http client')
+	@Betamax(tape = 'betamax http client', mode = TapeMode.READ_WRITE)
 	void 'can send a request with a body'() {
 		given:
 		endpoint.start(EchoHandler)
@@ -153,7 +153,7 @@ class BetamaxHttpClientSpec extends Specification {
 		!response.getFirstHeader('X-Betamax')
 	}
 
-	@Betamax(tape = 'betamax http client')
+	@Betamax(tape = 'betamax http client', mode = TapeMode.READ_WRITE)
 	void 'can use with HttpBuilder'() {
 		given:
 		endpoint.start(HelloHandler)

--- a/betamax-proxy/src/test/groovy/co/freeside/betamax/AnnotationSpec.groovy
+++ b/betamax-proxy/src/test/groovy/co/freeside/betamax/AnnotationSpec.groovy
@@ -39,7 +39,7 @@ class AnnotationSpec extends Specification {
 		recorder.tape == null
 	}
 
-	@Betamax(tape = 'annotation_spec')
+	@Betamax(tape = 'annotation_spec', mode = TapeMode.READ_WRITE)
 	void 'annotated feature can record'() {
 		given:
 		endpoint.start(EchoHandler)

--- a/betamax-proxy/src/test/groovy/co/freeside/betamax/compatibility/HttpBuilderSpec.groovy
+++ b/betamax-proxy/src/test/groovy/co/freeside/betamax/compatibility/HttpBuilderSpec.groovy
@@ -25,7 +25,7 @@ class HttpBuilderSpec extends Specification {
 	}
 
 	@Timeout(10)
-	@Betamax(tape = 'http builder spec')
+	@Betamax(tape = 'http builder spec', mode = TapeMode.READ_WRITE)
 	void 'proxy intercepts HTTPClient connections when using ProxySelectorRoutePlanner'() {
 		given:
 		def http = new RESTClient(endpoint.url)
@@ -40,7 +40,7 @@ class HttpBuilderSpec extends Specification {
 	}
 
 	@Timeout(10)
-	@Betamax(tape = 'http builder spec')
+	@Betamax(tape = 'http builder spec', mode = TapeMode.READ_WRITE)
 	void 'proxy intercepts HTTPClient connections when explicitly told to'() {
 		given:
 		def http = new RESTClient(endpoint.url)
@@ -55,7 +55,7 @@ class HttpBuilderSpec extends Specification {
 	}
 
 	@Timeout(10)
-	@Betamax(tape = 'http builder spec')
+	@Betamax(tape = 'http builder spec', mode = TapeMode.READ_WRITE)
 	void 'proxy intercepts HttpURLClient connections'() {
 		given:
 		def http = new HttpURLClient(url: endpoint.url)
@@ -69,7 +69,7 @@ class HttpBuilderSpec extends Specification {
 	}
 
 	@Timeout(10)
-	@Betamax(tape = 'http builder spec')
+	@Betamax(tape = 'http builder spec', mode = TapeMode.READ_WRITE)
 	void 'proxy automatically intercepts connections when the underlying client is a SystemDefaultHttpClient'() {
 		given:
 		def http = new BetamaxRESTClient(endpoint.url)

--- a/betamax-proxy/src/test/groovy/co/freeside/betamax/compatibility/HttpClient3Spec.groovy
+++ b/betamax-proxy/src/test/groovy/co/freeside/betamax/compatibility/HttpClient3Spec.groovy
@@ -22,7 +22,7 @@ class HttpClient3Spec extends Specification {
 	}
 
 	@Timeout(10)
-	@Betamax(tape = 'http client 3 spec')
+	@Betamax(tape = 'http client 3 spec', mode = TapeMode.READ_WRITE)
 	void 'proxy intercepts HTTPClient 3.x connections'() {
 		given:
 		def client = new HttpClient()

--- a/betamax-proxy/src/test/groovy/co/freeside/betamax/compatibility/HttpClientSpec.groovy
+++ b/betamax-proxy/src/test/groovy/co/freeside/betamax/compatibility/HttpClientSpec.groovy
@@ -29,7 +29,7 @@ class HttpClientSpec extends Specification {
 	}
 
 	@Timeout(10)
-	@Betamax(tape = 'http client spec')
+	@Betamax(tape = 'http client spec', mode = TapeMode.READ_WRITE)
 	void 'proxy intercepts HTTPClient connections when using ProxySelectorRoutePlanner'() {
 		given:
 		def http = new DefaultHttpClient()
@@ -45,7 +45,7 @@ class HttpClientSpec extends Specification {
 	}
 
 	@Timeout(10)
-	@Betamax(tape = 'http client spec')
+	@Betamax(tape = 'http client spec', mode = TapeMode.READ_WRITE)
 	void 'proxy intercepts HTTPClient connections when explicitly told to'() {
 		given:
 		def http = new DefaultHttpClient()
@@ -61,7 +61,7 @@ class HttpClientSpec extends Specification {
 	}
 
 	@Timeout(10)
-	@Betamax(tape = 'http client spec')
+	@Betamax(tape = 'http client spec', mode = TapeMode.READ_WRITE)
 	void 'proxy automatically intercepts SystemDefaultHttpClient connections'() {
 		given:
 		def http = new SystemDefaultHttpClient()

--- a/betamax-proxy/src/test/groovy/co/freeside/betamax/compatibility/HttpURLConnectionSpec.groovy
+++ b/betamax-proxy/src/test/groovy/co/freeside/betamax/compatibility/HttpURLConnectionSpec.groovy
@@ -24,7 +24,7 @@ class HttpURLConnectionSpec extends Specification {
 	}
 
 	@Timeout(10)
-	@Betamax(tape = 'http url connection spec')
+	@Betamax(tape = 'http url connection spec', mode = TapeMode.READ_WRITE)
 	void 'proxy intercepts URL connections'() {
 		given:
 		HttpURLConnection connection = new URL(endpoint.url).openConnection()

--- a/betamax-proxy/src/test/groovy/co/freeside/betamax/compatibility/WsLiteSpec.groovy
+++ b/betamax-proxy/src/test/groovy/co/freeside/betamax/compatibility/WsLiteSpec.groovy
@@ -24,7 +24,7 @@ class WsLiteSpec extends Specification {
 		httpsEndpoint.start(HelloHandler)
 	}
 
-	@Betamax(tape = 'wslite spec')
+	@Betamax(tape = 'wslite spec', mode = TapeMode.READ_WRITE)
 	void 'can record a connection made with WsLite'() {
 		given: 'a properly configured wslite instance'
 		def http = new RESTClient(endpoint.url)

--- a/betamax-proxy/src/test/groovy/co/freeside/betamax/proxy/PreExistingProxySpec.groovy
+++ b/betamax-proxy/src/test/groovy/co/freeside/betamax/proxy/PreExistingProxySpec.groovy
@@ -31,7 +31,7 @@ class PreExistingProxySpec extends Specification {
 	}
 
 	@Timeout(10)
-	@Betamax(tape = 'existing proxy spec')
+	@Betamax(tape = 'existing proxy spec', mode = TapeMode.READ_WRITE)
 	void 'pre-existing proxy settings are used for the outbound request from the Betamax proxy'() {
 		given:
 		HttpURLConnection connection = new URL('http://freeside.co/betamax').openConnection()

--- a/betamax-proxy/src/test/groovy/co/freeside/betamax/proxy/ProxyTimeoutSpec.groovy
+++ b/betamax-proxy/src/test/groovy/co/freeside/betamax/proxy/ProxyTimeoutSpec.groovy
@@ -24,7 +24,7 @@ class ProxyTimeoutSpec extends Specification {
 		http.client.httpRequestRetryHandler = new DefaultHttpRequestRetryHandler(0, false)
 	}
 
-	@Betamax(tape = 'proxy timeout spec')
+	@Betamax(tape = 'proxy timeout spec', mode = TapeMode.READ_WRITE)
 	void 'proxy responds with 504 if target server takes too long to respond'() {
 		given:
 		endpoint.start(SlowHandler)

--- a/betamax-proxy/src/test/groovy/co/freeside/betamax/proxy/RequestMethodsSpec.groovy
+++ b/betamax-proxy/src/test/groovy/co/freeside/betamax/proxy/RequestMethodsSpec.groovy
@@ -22,7 +22,7 @@ class RequestMethodsSpec extends Specification {
     }
 
     @Timeout(10)
-	@Betamax(tape = 'proxy network comms spec')
+	@Betamax(tape = 'proxy network comms spec', mode = TapeMode.READ_WRITE)
     void 'proxy handles #method requests'() {
         given:
         def http = new BetamaxRESTClient(endpoint.url)

--- a/betamax-proxy/src/test/groovy/co/freeside/betamax/recorder/RecorderConfigurationSpec.groovy
+++ b/betamax-proxy/src/test/groovy/co/freeside/betamax/recorder/RecorderConfigurationSpec.groovy
@@ -188,18 +188,4 @@ class RecorderConfigurationSpec extends Specification {
 		cleanup:
 		propertiesFile.delete()
 	}
-
-	@Issue('https://github.com/robfletcher/betamax/issues/56')
-	void 'default tape mode is set correctly on tape'() {
-		given:
-		def recorder = new ProxyRecorder(defaultMode: READ_ONLY)
-
-		when:
-		recorder.insertTape('foo', [mode: DEFAULT])
-
-		then:
-		recorder.tape.isReadable()
-		!recorder.tape.isWritable()
-	}
-
 }


### PR DESCRIPTION
Using a Groovy boolean expression on TapeMode.DEFAULT caused some unexpected logic, mostly revolving around constantly defaulting to TapeMode.READ_ONLY.

As a fix, I removed TapeMode.DEFAULT because it doesn't provide any real value, and defaulted to TapeMode.READ_ONLY.

Tests are fixed to use TapeMode.READ_WRITE where appropriate. IMO, better to be explicit when changing data than not.
