### PR TITLE
TapeModeSpec on Windows

### DIFF
--- a/betamax-core/src/test/groovy/co/freeside/betamax/recorder/TapeModeSpec.groovy
+++ b/betamax-core/src/test/groovy/co/freeside/betamax/recorder/TapeModeSpec.groovy
@@ -45,8 +45,8 @@ class TapeModeSpec extends Specification {
 
 	void 'in #mode mode a new interaction recorded'() {
 		given: 'an empty write-only tape is inserted'
-        new File(tapeRoot, 'blank_tape_' + mode + '.yaml').delete()
-        recorder.insertTape('blank tape ' + mode, [mode: mode])
+		new File(tapeRoot, 'blank_tape_' + mode + '.yaml').delete()
+		recorder.insertTape('blank tape ' + mode, [mode: mode])
 		def tape = recorder.tape
 
 		when: 'a request is made'


### PR DESCRIPTION
I have a fix for this test when running on Windows.  The problem seems to occur because the cleanup isn't happening between each test run.  To resolve the issue I've made the tape name unique per run by including the 'mode' in the tape name and moving the cleanup of the tape file to the given block instead of cleanup.

Interestingly the temp directory that gets created never gets deleted on Windows either, even though it is annotated with @AutoCleanup. Strange.

I understand if you don't want to accept this pull request as ultimately I'm introducing a code change to get round what looks like a Spock problem on Windows. I should move to coding on my Linux VM :) Feel free to just close.
