### PR TITLE
Removed constructor to allow compilation on Java 1.6

### DIFF
--- a/betamax-core/src/main/java/co/freeside/betamax/tape/TapeReadException.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/tape/TapeReadException.java
@@ -33,7 +33,4 @@ public class TapeReadException extends RuntimeException {
         super(cause);
     }
 
-    protected TapeReadException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }


### PR DESCRIPTION
Fix for issue #110. The constructor in question does not appear to be invoked from anywhere.
