### PR TITLE
Added link to (correct) smoke_spec.yaml

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Add a `@Rule RecorderRule` property to your test and annotate test methods with 
 Future test runs replay responses from _tape_ without traffic going to the real target. No more 3rd party downtime or rate limits breaking your tests. You can even run your tests offline! Insert different _tapes_ to stub different responses.
 
 ### Customize
-_Tapes_ are just [YAML][yaml] files so you can edit them with a text editor, commit to source control, share with your team & use on continuous integration.
+_Tapes_ are just [YAML][yaml] files so you can edit them with a text editor, commit to source control, share with your team & use on continuous integration.  An example tape file can be found [here](https://github.com/robfletcher/betamax/blob/master/betamax-proxy/src/test/resources/betamax/tapes/smoke_spec.yaml).
 
 ## Full documentation
 


### PR DESCRIPTION
Hi, the link to smoke_spec.yaml you have on http://freeside.co/betamax/ in "An example tape file can be found here." is wrong.  I don't know where the src for http://freeside.co/betamax/ is, so instead of just added it to the readme - maybe you want to change http://freeside.co/betamax/ too.

PS: I blogged http://blog2.vorburger.ch/2013/11/rest-api-testing-and-mocking.html yesterday, and (via a friend) found your Betamax today.. ;-) Good stuff. I'll try to use it in https://github.com/vorburger/mifosx-ui-selenium-webdriver-tests

PPS: Any thoughts re. the idea to replay a tape against a server? If yes, let's discuss in https://github.com/robfletcher/betamax/issues/119 - @lbovet who just opened it is sitting right opposite me... ;-)
