### PR TITLE
Fix compilation on JDK8

### DIFF
--- a/betamax-core/src/main/java/co/freeside/betamax/Recorder.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/Recorder.java
@@ -16,7 +16,7 @@
 
 package co.freeside.betamax;
 
-import java.util.*;
+import java.util.Collection;
 import co.freeside.betamax.internal.*;
 import co.freeside.betamax.tape.*;
 import co.freeside.betamax.tape.yaml.*;


### PR DESCRIPTION
Importing java.util.\* leads to ambiguity under JDK8, due to the addition of java.util.Optional.
