### PR TITLE
Proposed fix for encoding issue

### DIFF
--- a/betamax-core/src/main/java/co/freeside/betamax/tape/MemoryTape.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/tape/MemoryTape.java
@@ -15,43 +15,27 @@
  */
 
 package co.freeside.betamax.tape;
-
-import static co.freeside.betamax.Headers.X_BETAMAX;
-import static com.google.common.net.HttpHeaders.VIA;
-import static java.util.Collections.unmodifiableList;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
+import java.io.*;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
-import co.freeside.betamax.Configuration;
-import co.freeside.betamax.MatchRule;
-import co.freeside.betamax.TapeMode;
+import co.freeside.betamax.*;
 import co.freeside.betamax.encoding.DeflateEncoder;
 import co.freeside.betamax.encoding.GzipEncoder;
 import co.freeside.betamax.encoding.NoOpEncoder;
 import co.freeside.betamax.handler.NonWritableTapeException;
-import co.freeside.betamax.io.FileResolver;
-import co.freeside.betamax.io.FileTypeMapper;
-import co.freeside.betamax.io.FilenameNormalizer;
-import co.freeside.betamax.message.Message;
-import co.freeside.betamax.message.Request;
-import co.freeside.betamax.message.Response;
-import co.freeside.betamax.message.tape.RecordedMessage;
-import co.freeside.betamax.message.tape.RecordedRequest;
-import co.freeside.betamax.message.tape.RecordedResponse;
+import co.freeside.betamax.io.*;
+import co.freeside.betamax.message.*;
+import co.freeside.betamax.message.tape.*;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.io.ByteStreams;
-import com.google.common.io.CharStreams;
-import com.google.common.io.Files;
+import com.google.common.collect.*;
+import com.google.common.io.*;
+
+import static co.freeside.betamax.Headers.X_BETAMAX;
+import static com.google.common.net.HttpHeaders.VIA;
+import static java.util.Collections.unmodifiableList;
 
 /**
  * Represents a set of recorded HTTP interactions that can be played back or

--- a/betamax-core/src/test/groovy/co/freeside/betamax/tape/TapeWithZipDataSpec.groovy
+++ b/betamax-core/src/test/groovy/co/freeside/betamax/tape/TapeWithZipDataSpec.groovy
@@ -1,0 +1,95 @@
+package co.freeside.betamax.tape
+import co.freeside.betamax.encoding.DeflateEncoder
+import co.freeside.betamax.encoding.GzipEncoder
+import co.freeside.betamax.message.Request
+import co.freeside.betamax.message.Response
+import co.freeside.betamax.tape.yaml.YamlTapeLoader
+import co.freeside.betamax.util.message.BasicRequest
+import co.freeside.betamax.util.message.BasicResponse
+import com.google.common.io.Files
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static co.freeside.betamax.TapeMode.READ_WRITE
+import static com.google.common.net.HttpHeaders.*
+
+@Unroll
+class TapeWithZipDataSpec extends Specification {
+	@Shared @AutoCleanup("deleteDir") def tapeRoot = Files.createTempDir()
+	@Shared def loader = new YamlTapeLoader(tapeRoot)
+	@Shared Tape tape = loader.loadTape('tape_spec')
+
+	Request getRequest = new BasicRequest('GET', 'http://qwantz.com/')
+    Response encodedGZipResponse;
+    static final PLAIN_TEXT_BODY = 'O HAI!'
+
+	void setup() {
+        encodedGZipResponse = new BasicResponse(status: 200, reason: 'OK')
+		encodedGZipResponse.addHeader(CONTENT_TYPE, 'text/plain;charset=UTF-8')
+		encodedGZipResponse.addHeader(CONTENT_LANGUAGE, 'en-GB')
+	}
+
+	void setupSpec() {
+		tape.mode = READ_WRITE
+	}
+
+	void 'encoded text body with #encoding encoding is correctly stored on tape'() {
+		when: 'the response body is encoded'
+        encodedGZipResponse.addHeader(CONTENT_ENCODING, encoding)
+		encodedGZipResponse.body = encoder.encode(PLAIN_TEXT_BODY.bytes)
+
+		and: 'the HTTP interaction is recorded to tape'
+		tape.record(getRequest, encodedGZipResponse)
+
+		then: 'an interaction has occurred'
+		def interaction = tape.interactions[-1]
+
+		and: 'the request data is correctly stored'
+		interaction.request.method == getRequest.method
+		interaction.request.uri == getRequest.uri
+
+		and: 'the response status and headers are correctly stored on tape'
+		interaction.response.status == encodedGZipResponse.status
+		interaction.response.headers[CONTENT_TYPE] == encodedGZipResponse.getHeader(CONTENT_TYPE)
+		interaction.response.headers[CONTENT_LANGUAGE] == encodedGZipResponse.getHeader(CONTENT_LANGUAGE)
+		interaction.response.headers[CONTENT_ENCODING] == encodedGZipResponse.getHeader(CONTENT_ENCODING)
+
+		and: 'the response body is correctly stored as decoded on tape'
+		interaction.response.body == PLAIN_TEXT_BODY
+
+		where:
+        encoderClass << [GzipEncoder, DeflateEncoder]
+        encoding << ["gzip", "deflate"]
+        encoder = encoderClass.newInstance()
+	}
+
+    void 'plain text body with #encoding encoding is correctly stored on tape, using fallback'() {
+        when: 'the response body is encoded'
+        encodedGZipResponse.addHeader(CONTENT_ENCODING, encoding)
+        encodedGZipResponse.body = PLAIN_TEXT_BODY
+
+        and: 'the HTTP interaction is recorded to tape'
+        tape.record(getRequest, encodedGZipResponse)
+
+        then: 'an interaction has occurred'
+        def interaction = tape.interactions[-1]
+
+        and: 'the request data is correctly stored'
+        interaction.request.method == getRequest.method
+        interaction.request.uri == getRequest.uri
+
+        and: 'the response status and headers are correctly stored on tape'
+        interaction.response.status == encodedGZipResponse.status
+        interaction.response.headers[CONTENT_TYPE] == encodedGZipResponse.getHeader(CONTENT_TYPE)
+        interaction.response.headers[CONTENT_LANGUAGE] == encodedGZipResponse.getHeader(CONTENT_LANGUAGE)
+        interaction.response.headers[CONTENT_ENCODING] == encodedGZipResponse.getHeader(CONTENT_ENCODING)
+
+        and: 'the response body is correctly stored as decoded on tape'
+        interaction.response.body == PLAIN_TEXT_BODY
+
+        where:
+        encoding << ["gzip", "deflate"]
+    }
+}


### PR DESCRIPTION
Possible fix for <a href="https://github.com/robfletcher/betamax/issues/135">Issue #135</a>.

The issue was that binary response bodies were being saved in encoded form, and played back after being encoded once more in BetamaxFilters. The fix was to save compressed response bodies in human readable form on tape and encode on their way to the browser.