### PR TITLE
JRuby support

### DIFF
--- a/betamax-core/src/main/java/co/freeside/betamax/tape/yaml/YamlTapeLoader.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/tape/yaml/YamlTapeLoader.java
@@ -85,8 +85,10 @@ public class YamlTapeLoader implements TapeLoader<YamlTape> {
     @VisibleForTesting
     public YamlTape readFrom(Reader reader) {
         try {
-            return getYaml().loadAs(reader, YamlTape.class);
+            return (YamlTape) getYaml().load(reader);
         } catch (YAMLException e) {
+            throw new TapeLoadException("Invalid tape", e);
+        } catch (ClassCastException e) { // Valid YAML, but not a YamlTape!
             throw new TapeLoadException("Invalid tape", e);
         }
     }

--- a/betamax-core/src/test/groovy/co/freeside/betamax/tape/ReadTapeFromYamlSpec.groovy
+++ b/betamax-core/src/test/groovy/co/freeside/betamax/tape/ReadTapeFromYamlSpec.groovy
@@ -127,7 +127,7 @@ interactions:
 
     void "barfs on non-yaml data"() {
         given:
-        def yaml = "THIS IS NOT YAML"
+        def yaml = "{}][: THIS IS NOT YAML"
 
         when:
         loader.readFrom(new StringReader(yaml))

--- a/betamax-core/src/test/groovy/co/freeside/betamax/tape/ReadTapeFromYamlSpec.groovy
+++ b/betamax-core/src/test/groovy/co/freeside/betamax/tape/ReadTapeFromYamlSpec.groovy
@@ -136,6 +136,17 @@ interactions:
         thrown TapeLoadException
     }
 
+    void "barfs on yaml data which is not a YamlTape"() {
+        given:
+        def yaml = "this is valid yaml"
+
+        when:
+        loader.readFrom(new StringReader(yaml))
+
+        then:
+        thrown TapeLoadException
+    }
+
     void "barfs on an invalid record date"() {
         given:
         def yaml = """\


### PR DESCRIPTION
JRuby support.

* Encourage YAML to use the type description configured by YamlTapeLoader#getYaml().
  Specifically, SnakeYAML's loadAs(reader, type) overrides root element tag
  in preference to 'type', if provided. See BaseConstructor#getSingletonData().

* This breaks in JRuby because of some JRuby/SnakeYAML messiness:
  (1) the "overridden" root element tag will not perfectly match the tag found
  in the serialized YAML. One is constructed with YamlTape.class, the other with "!tape".
  (2) because they do not perfectly match, SnakeYAML prefers the overridde tag
  (the one constructed with YamlTape.class).
  (3) Tags constructed with Class objects only retain the class name (a String).
  (4) SnakeYAML uses Class.forName() to dereference this String...
  (5) ... which will fail in JRuby, because JRuby includes SnakeYAML in the bootstrap
  classpath and has no access to betamax classes.

* Without this 'overridden' tag, it uses the type description mapping configured in
  YamlTapeLoader#getYaml(), which contains a hard reference to YamlTape.class.

* Preserve existing exception behavior when loading VALID yaml which is not a YamlTape.