### PR TITLE
Binary POST requests

### DIFF
--- a/betamax-core/src/main/java/co/freeside/betamax/io/BodyConverter.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/io/BodyConverter.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package co.freeside.betamax.io;
+
+import co.freeside.betamax.Configuration;
+import co.freeside.betamax.message.Message;
+import co.freeside.betamax.message.tape.RecordedMessage;
+import co.freeside.betamax.tape.EntityStorage;
+import com.google.common.io.*;
+import java.io.*;
+
+/**
+ * Handles the conversion of HTTP bodies between raw wire form and a (hopefully) more readable
+ * representation of it -- for example, between a gzipped and UTF-8 encoded string (byte[]), and
+ * its java.lang.String equivalent.
+ * <p/>
+ * We may fall back, when we cannot understand a {@link co.freeside.betamax.message.Message}'s
+ * Content-Type and Content-Encoding, to a no-op conversion, and simply use the raw bytes to
+ * save the body to tape (usually resulting in unreadable base-64 encoded bytes written out to yaml).
+ * <p/>
+ * Created by IntelliJ IDEA. 9/14/14, 12:03 PM
+ *
+ * @author igrayson
+ */
+public final class BodyConverter {
+
+    private final FileResolver fileResolver;
+
+    private EntityStorage responseBodyStorage = Configuration.DEFAULT_RESPONSE_BODY_STORAGE;
+
+    public BodyConverter(FileResolver fileResolver) {
+        this.fileResolver = fileResolver;
+    }
+
+    /**
+     * Convert the raw HTTP body of the provided {@link co.freeside.betamax.message.Message} into a serializable,
+     * intermediary form. For example, this may convert a UTF8-encoded body to a {@link java.lang.String}.
+     * <p/>
+     * At its option (i.e., in the case of unknown or invalid encoding), this method may perform a no-op conversion
+     * of the raw HTTP body to a byte[].
+     *
+     * @param message       HTTP message whose body is to be recorded.  The entire
+     *                      {@link co.freeside.betamax.message.tape.RecordedMessage} is provided for access to metadata
+     *                      useful in detecting the conversion required.
+     * @param tapeName      name of the tape
+     * @param interactionId some opaque identifier for this transaction, unique within the scope of this tape
+     * @return the message's body, in YAML-serializable form
+     * @throws IOException indicates unexpected failure in the conversion process.
+     * @see org.yaml.snakeyaml.representer.SafeRepresenter for a list of serializable types SnakeYAML automatically
+     * understands.
+     */
+    public Object toRecordedForm(final Message message, final String tapeName, final String interactionId) throws IOException {
+        if (EntityStorage.external == responseBodyStorage) {
+            return recordBodyToFile(message, tapeName, interactionId);
+        } else if (ContentTypes.isTextContentType(message.getContentType())) {
+            return CharStreams.toString(message.getBodyAsText());
+        } else {
+            return ByteStreams.toByteArray(message.getBodyAsBinary());
+        }
+    }
+
+    /**
+     * Convert the serializable HTTP body of a recorded message to a wire-ready form.
+     *
+     * @param message recorded message containing the HTTP body in serializable form.  The entire
+     *                {@link co.freeside.betamax.message.tape.RecordedMessage} is provided for access to metadata useful
+     *                in detecting the conversion required.
+     * @return raw http body
+     * @throws IOException indicates unexpected failure in the conversion process
+     */
+    public byte[] toWireForm(final RecordedMessage message) throws IOException {
+        Object body = message.getBody();
+        return body instanceof String ? ((String) body).getBytes(message.getCharset()) : (byte[]) body;
+    }
+
+    public void setResponseBodyStorage(EntityStorage responseBodyStorage) {
+        this.responseBodyStorage = responseBodyStorage;
+    }
+
+    private File recordBodyToFile(final Message message, final String tapeName, final String interactionId) throws IOException {
+        String filename = FileTypeMapper.filenameFor(String.format("response-%s", interactionId), message.getContentType());
+        File body = fileResolver.toFile(FilenameNormalizer.toFilename(tapeName), filename);
+        Files.createParentDirs(body);
+        ByteStreams.copy(message.getBodyAsBinary(), Files.newOutputStreamSupplier(body));
+        return body;
+    }
+
+}

--- a/betamax-core/src/main/java/co/freeside/betamax/message/Message.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/message/Message.java
@@ -57,8 +57,7 @@ public interface Message {
     InputSupplier<Reader> getBodyAsText();
 
     /**
-     * Returns the decoded message body. If the implementation stores the message body in an encoded form (e.g. gzipped) then it <em>must</em> be decoded
-     * before being returned by this method
+     * Returns the raw (wire-level) body. Does not decode or otherwise modify the payload.
      *
      * @return the message body as binary data.
      * @throws IllegalStateException if the message does not have a body.

--- a/betamax-core/src/main/java/co/freeside/betamax/message/tape/RecordedRequest.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/message/tape/RecordedRequest.java
@@ -16,11 +16,17 @@
 
 package co.freeside.betamax.message.tape;
 
+import co.freeside.betamax.io.BodyConverter;
 import co.freeside.betamax.message.Request;
 
 import java.net.URI;
 
 public class RecordedRequest extends RecordedMessage implements Request {
+
+    public RecordedRequest(BodyConverter bodyConverter) {
+        super(bodyConverter);
+    }
+
     public String getMethod() {
         return method;
     }

--- a/betamax-core/src/main/java/co/freeside/betamax/message/tape/RecordedResponse.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/message/tape/RecordedResponse.java
@@ -16,9 +16,15 @@
 
 package co.freeside.betamax.message.tape;
 
+import co.freeside.betamax.io.BodyConverter;
 import co.freeside.betamax.message.Response;
 
 public class RecordedResponse extends RecordedMessage implements Response {
+
+    public RecordedResponse(BodyConverter bodyConverter) {
+        super(bodyConverter);
+    }
+
     public int getStatus() {
         return status;
     }

--- a/betamax-core/src/main/java/co/freeside/betamax/tape/MemoryTape.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/tape/MemoryTape.java
@@ -43,13 +43,12 @@ public abstract class MemoryTape implements Tape {
 
     private transient TapeMode mode = Configuration.DEFAULT_MODE;
     private transient MatchRule matchRule = Configuration.DEFAULT_MATCH_RULE;
-    private transient EntityStorage responseBodyStorage = Configuration.DEFAULT_RESPONSE_BODY_STORAGE;
-    private final transient FileResolver fileResolver;
+    private final transient BodyConverter bodyConverter;
 
     private transient AtomicInteger orderedIndex = new AtomicInteger();
 
-    protected MemoryTape(FileResolver fileResolver) {
-        this.fileResolver = fileResolver;
+    protected MemoryTape(BodyConverter bodyConverter) {
+        this.bodyConverter = bodyConverter;
     }
 
     @Override
@@ -78,7 +77,7 @@ public abstract class MemoryTape implements Tape {
 
     @Override
     public void setResponseBodyStorage(EntityStorage responseBodyStorage) {
-        this.responseBodyStorage = responseBodyStorage;
+        this.bodyConverter.setResponseBodyStorage(responseBodyStorage);
     }
 
     @Override
@@ -205,7 +204,7 @@ public abstract class MemoryTape implements Tape {
 
     private RecordedRequest recordRequest(Request request) {
         try {
-            final RecordedRequest recording = new RecordedRequest();
+            final RecordedRequest recording = new RecordedRequest(this.bodyConverter);
             recording.setMethod(request.getMethod());
             recording.setUri(request.getUri());
 
@@ -216,7 +215,7 @@ public abstract class MemoryTape implements Tape {
             }
 
             if (request.hasBody()) {
-                recordBodyInline(request, recording);
+                recording.recordBody(request, this.name, "" + (size() + 1));
             }
 
             return recording;
@@ -227,7 +226,7 @@ public abstract class MemoryTape implements Tape {
 
     private RecordedResponse recordResponse(Response response) {
         try {
-            RecordedResponse recording = new RecordedResponse();
+            RecordedResponse recording = new RecordedResponse(this.bodyConverter);
             recording.setStatus(response.getStatus());
 
             for (Map.Entry<String, String> header : response.getHeaders().entrySet()) {
@@ -237,44 +236,13 @@ public abstract class MemoryTape implements Tape {
             }
 
             if (response.hasBody()) {
-                recordResponseBody(response, recording);
+                recording.recordBody(response, this.name, "" + (size() + 1));
             }
 
             return recording;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private void recordResponseBody(Response response, RecordedResponse recording) throws IOException {
-        switch (responseBodyStorage) {
-            case external:
-                recordBodyToFile(response, recording);
-                break;
-            default:
-                recordBodyInline(response, recording);
-        }
-    }
-
-    private void recordBodyInline(Message message, RecordedMessage recording) throws IOException {
-        boolean representAsText = isTextContentType(message.getContentType());
-        if (representAsText) {
-            recording.setBody(CharStreams.toString(message.getBodyAsText()));
-        } else {
-            recording.setBody(ByteStreams.toByteArray(message.getBodyAsBinary()));
-        }
-    }
-
-    private void recordBodyToFile(Message message, RecordedMessage recording) throws IOException {
-        String filename = FileTypeMapper.filenameFor(String.format("response-%02d", size() + 1), message.getContentType());
-        File body = fileResolver.toFile(FilenameNormalizer.toFilename(name), filename);
-        Files.createParentDirs(body);
-        ByteStreams.copy(message.getBodyAsBinary(), Files.newOutputStreamSupplier(body));
-        recording.setBody(body);
-    }
-
-    public static boolean isTextContentType(String contentType) {
-        return contentType != null && ContentTypes.isTextContentType(contentType);
     }
 
 }

--- a/betamax-core/src/main/java/co/freeside/betamax/tape/MemoryTape.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/tape/MemoryTape.java
@@ -16,10 +16,6 @@
 
 package co.freeside.betamax.tape;
 
-import java.io.*;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Pattern;
 import co.freeside.betamax.*;
 import co.freeside.betamax.handler.NonWritableTapeException;
 import co.freeside.betamax.io.*;
@@ -28,6 +24,10 @@ import co.freeside.betamax.message.tape.*;
 import com.google.common.base.Predicate;
 import com.google.common.collect.*;
 import com.google.common.io.*;
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static co.freeside.betamax.Headers.X_BETAMAX;
 import static com.google.common.net.HttpHeaders.VIA;
 import static java.util.Collections.unmodifiableList;
@@ -203,7 +203,7 @@ public abstract class MemoryTape implements Tape {
         });
     }
 
-    private static RecordedRequest recordRequest(Request request) {
+    private RecordedRequest recordRequest(Request request) {
         try {
             final RecordedRequest recording = new RecordedRequest();
             recording.setMethod(request.getMethod());
@@ -216,7 +216,7 @@ public abstract class MemoryTape implements Tape {
             }
 
             if (request.hasBody()) {
-                recording.setBody(CharStreams.toString(request.getBodyAsText()));
+                recordBodyInline(request, recording);
             }
 
             return recording;
@@ -274,7 +274,7 @@ public abstract class MemoryTape implements Tape {
     }
 
     public static boolean isTextContentType(String contentType) {
-        return contentType != null && Pattern.compile("^text/|application/(json|javascript|(\\w+\\+)?xml)").matcher(contentType).find();
+        return contentType != null && ContentTypes.isTextContentType(contentType);
     }
 
 }

--- a/betamax-core/src/main/java/co/freeside/betamax/tape/yaml/TapeConstructor.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/tape/yaml/TapeConstructor.java
@@ -16,30 +16,35 @@
 
 package co.freeside.betamax.tape.yaml;
 
-import co.freeside.betamax.io.FileResolver;
+import co.freeside.betamax.io.*;
+import co.freeside.betamax.message.tape.*;
 import org.yaml.snakeyaml.constructor.*;
 import org.yaml.snakeyaml.nodes.*;
 import static co.freeside.betamax.tape.yaml.YamlTape.FILE_TAG;
 
 public class TapeConstructor extends Constructor {
 
-    public TapeConstructor(FileResolver fileResolver) {
-        yamlClassConstructors.put(NodeId.mapping, new ConstructTape(fileResolver));
+    public TapeConstructor(FileResolver fileResolver, BodyConverter bodyConverter) {
+        yamlClassConstructors.put(NodeId.mapping, new ConstructTape(bodyConverter));
         yamlConstructors.put(FILE_TAG, new ConstructFile(fileResolver));
     }
 
     private class ConstructTape extends ConstructMapping {
 
-        private final FileResolver fileResolver;
+        private final BodyConverter bodyConverter;
 
-        public ConstructTape(FileResolver fileResolver) {
-            this.fileResolver = fileResolver;
+        public ConstructTape(BodyConverter bodyConverter) {
+            this.bodyConverter = bodyConverter;
         }
 
         @Override
         protected Object createEmptyJavaBean(MappingNode node) {
             if (YamlTape.class.equals(node.getType())) {
-                return new YamlTape(fileResolver);
+                return new YamlTape(bodyConverter);
+            } else if (RecordedResponse.class.equals(node.getType())) {
+                return new RecordedResponse(bodyConverter);
+            } else if (RecordedRequest.class.equals(node.getType())) {
+                return new RecordedRequest(bodyConverter);
             } else {
                 return super.createEmptyJavaBean(node);
             }

--- a/betamax-core/src/main/java/co/freeside/betamax/tape/yaml/YamlTape.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/tape/yaml/YamlTape.java
@@ -28,8 +28,8 @@ class YamlTape extends MemoryTape {
 
     private transient boolean dirty;
 
-    YamlTape(FileResolver fileResolver) {
-        super(fileResolver);
+    YamlTape(BodyConverter bodyConverter) {
+        super(bodyConverter);
     }
 
     @Override

--- a/betamax-core/src/main/java/co/freeside/betamax/tape/yaml/YamlTapeLoader.java
+++ b/betamax-core/src/main/java/co/freeside/betamax/tape/yaml/YamlTapeLoader.java
@@ -36,11 +36,13 @@ public class YamlTapeLoader implements TapeLoader<YamlTape> {
     public static final String FILE_CHARSET = "UTF-8";
 
     private final FileResolver fileResolver;
+    private final BodyConverter bodyConverter;
 
     private static final Logger LOG = Logger.getLogger(YamlTapeLoader.class.getName());
 
     public YamlTapeLoader(File tapeRoot) {
         fileResolver = new FileResolver(tapeRoot);
+        bodyConverter = new BodyConverter(fileResolver);
     }
 
     public YamlTape loadTape(String name) {
@@ -77,7 +79,7 @@ public class YamlTapeLoader implements TapeLoader<YamlTape> {
 
     @VisibleForTesting
     public YamlTape newTape(String name) {
-        YamlTape tape = new YamlTape(fileResolver);
+        YamlTape tape = new YamlTape(this.bodyConverter);
         tape.setName(name);
         return tape;
     }
@@ -109,7 +111,7 @@ public class YamlTapeLoader implements TapeLoader<YamlTape> {
         Representer representer = new TapeRepresenter(fileResolver);
         representer.addClassTag(YamlTape.class, TAPE_TAG);
 
-        Constructor constructor = new TapeConstructor(fileResolver);
+        Constructor constructor = new TapeConstructor(fileResolver, bodyConverter);
         constructor.addTypeDescription(new TypeDescription(YamlTape.class, TAPE_TAG));
 
         DumperOptions dumperOptions = new DumperOptions();

--- a/betamax-core/src/test/groovy/co/freeside/betamax/MatchRuleSpec.groovy
+++ b/betamax-core/src/test/groovy/co/freeside/betamax/MatchRuleSpec.groovy
@@ -16,20 +16,32 @@
 
 package co.freeside.betamax
 
+import co.freeside.betamax.io.BodyConverter
 import co.freeside.betamax.message.tape.RecordedRequest
 import co.freeside.betamax.util.message.BasicRequest
-import spock.lang.*
+import spock.lang.Issue
+import spock.lang.Specification
+
 import static co.freeside.betamax.MatchRules.*
-import static com.google.common.net.HttpHeaders.*
+import static com.google.common.net.HttpHeaders.ACCEPT_ENCODING
+import static com.google.common.net.HttpHeaders.CACHE_CONTROL
 
 @Issue('https://github.com/robfletcher/betamax/issues/9')
 class MatchRuleSpec extends Specification {
 
+    def req(args) {
+        def req = new RecordedRequest(new BodyConverter(null))
+        args.each() { attr, val ->
+            req[attr] = val
+        }
+        return req
+    }
+
     void 'can match method and url'() {
         given:
-        def request1 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
-        def request2 = new RecordedRequest(method: 'HEAD', uri: 'http://freeside.co/betamax'.toURI())
-        def request3 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax?q=1'.toURI())
+        def request1 = req(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
+        def request2 = req(method: 'HEAD', uri: 'http://freeside.co/betamax'.toURI())
+        def request3 = req(method: 'GET', uri: 'http://freeside.co/betamax?q=1'.toURI())
 
         and:
         def request = new BasicRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
@@ -43,10 +55,10 @@ class MatchRuleSpec extends Specification {
 
     void 'can match host'() {
         given:
-        def request1 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
-        def request2 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/grails-fields'.toURI())
-        def request3 = new RecordedRequest(method: 'HEAD', uri: 'http://freeside.co/betamax'.toURI())
-        def request4 = new RecordedRequest(method: 'GET', uri: 'http://icanhascheezburger.com/'.toURI())
+        def request1 = req(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
+        def request2 = req(method: 'GET', uri: 'http://freeside.co/grails-fields'.toURI())
+        def request3 = req(method: 'HEAD', uri: 'http://freeside.co/betamax'.toURI())
+        def request4 = req(method: 'GET', uri: 'http://icanhascheezburger.com/'.toURI())
 
         and:
         def request = new BasicRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
@@ -61,10 +73,10 @@ class MatchRuleSpec extends Specification {
 
     void 'can match path'() {
         given:
-        def request1 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
-        def request2 = new RecordedRequest(method: 'GET', uri: 'http://robfletcher.github.com/grails-enhanced-scaffolding'.toURI())
-        def request3 = new RecordedRequest(method: 'HEAD', uri: 'http://freeside.co/betamax'.toURI())
-        def request4 = new RecordedRequest(method: 'GET', uri: 'http://icanhascheezburger.com/betamax'.toURI())
+        def request1 = req(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
+        def request2 = req(method: 'GET', uri: 'http://robfletcher.github.com/grails-enhanced-scaffolding'.toURI())
+        def request3 = req(method: 'HEAD', uri: 'http://freeside.co/betamax'.toURI())
+        def request4 = req(method: 'GET', uri: 'http://icanhascheezburger.com/betamax'.toURI())
 
         and:
         def request = new BasicRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
@@ -79,10 +91,10 @@ class MatchRuleSpec extends Specification {
 
     void 'can match headers'() {
         given:
-        def request1 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI(), headers: [(ACCEPT_ENCODING): 'gzip, deflate'])
-        def request2 = new RecordedRequest(method: 'GET', uri: 'http://icanhascheezburger.com/'.toURI(), headers: [(ACCEPT_ENCODING): 'gzip, deflate'])
-        def request3 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI(), headers: [(ACCEPT_ENCODING): 'none'])
-        def request4 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI(), headers: [(ACCEPT_ENCODING): 'gzip, deflate', (CACHE_CONTROL): 'no-cache'])
+        def request1 = req(method: 'GET', uri: 'http://freeside.co/betamax'.toURI(), headers: [(ACCEPT_ENCODING): 'gzip, deflate'])
+        def request2 = req(method: 'GET', uri: 'http://icanhascheezburger.com/'.toURI(), headers: [(ACCEPT_ENCODING): 'gzip, deflate'])
+        def request3 = req(method: 'GET', uri: 'http://freeside.co/betamax'.toURI(), headers: [(ACCEPT_ENCODING): 'none'])
+        def request4 = req(method: 'GET', uri: 'http://freeside.co/betamax'.toURI(), headers: [(ACCEPT_ENCODING): 'gzip, deflate', (CACHE_CONTROL): 'no-cache'])
 
         and:
         def request = new BasicRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI(), headers: [(ACCEPT_ENCODING): ['gzip', 'deflate']])
@@ -97,9 +109,9 @@ class MatchRuleSpec extends Specification {
 
     void 'can match post body'() {
         given:
-        def request1 = new RecordedRequest(method: 'POST', uri: 'http://freeside.co/betamax'.toURI(), body: 'q=1')
-        def request2 = new RecordedRequest(method: 'POST', uri: 'http://freeside.co/betamax'.toURI(), body: 'q=2')
-        def request3 = new RecordedRequest(method: 'POST', uri: 'http://freeside.co/betamax'.toURI(), body: 'q=1&r=1')
+        def request1 = req(method: 'POST', uri: 'http://freeside.co/betamax'.toURI(), body: 'q=1')
+        def request2 = req(method: 'POST', uri: 'http://freeside.co/betamax'.toURI(), body: 'q=2')
+        def request3 = req(method: 'POST', uri: 'http://freeside.co/betamax'.toURI(), body: 'q=1&r=1')
 
         and:
         def request = new BasicRequest(method: 'POST', uri: 'http://freeside.co/betamax'.toURI(), body: 'q=1')

--- a/betamax-core/src/test/groovy/co/freeside/betamax/tape/ContentTypeSpec.groovy
+++ b/betamax-core/src/test/groovy/co/freeside/betamax/tape/ContentTypeSpec.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package co.freeside.betamax.tape
+
+import co.freeside.betamax.message.Response
+import co.freeside.betamax.tape.yaml.YamlTapeLoader
+import co.freeside.betamax.util.message.BasicRequest
+import co.freeside.betamax.util.message.BasicResponse
+import com.google.common.io.Files
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static co.freeside.betamax.TapeMode.READ_WRITE
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE
+import static java.net.HttpURLConnection.HTTP_OK
+
+class ContentTypeSpec extends Specification {
+
+    @Shared @AutoCleanup("deleteDir") def tapeRoot = Files.createTempDir()
+    @Shared def loader = new YamlTapeLoader(tapeRoot)
+    @Shared Tape tape = loader.loadTape('tape_spec')
+    @Shared File image = new File(Class.getResource("/image.png").toURI())
+
+    @Shared Response successResponse = new BasicResponse(HTTP_OK, "OK")
+
+    void setup() {
+        tape.mode = READ_WRITE
+    }
+    
+    void 'can record post requests with an image content-type'() {
+        given: 'a request with some content'
+        def imagePostRequest = new BasicRequest("POST", "http://github.com/")
+        imagePostRequest.addHeader(CONTENT_TYPE, "image/png")
+        imagePostRequest.body = image.bytes
+
+        when: 'the request and its response are recorded'
+        tape.record(imagePostRequest, successResponse)
+
+        then: 'the request body is stored on the tape'
+        def interaction = tape.interactions[-1]
+        interaction.request.body == imagePostRequest.bodyAsBinary.input.bytes
+    }
+
+
+}

--- a/betamax-core/src/test/groovy/co/freeside/betamax/tape/ExternalBodySpec.groovy
+++ b/betamax-core/src/test/groovy/co/freeside/betamax/tape/ExternalBodySpec.groovy
@@ -15,19 +15,17 @@
  */
 
 package co.freeside.betamax.tape
-
 import co.freeside.betamax.io.FilenameNormalizer
 import co.freeside.betamax.tape.yaml.YamlTapeLoader
-import co.freeside.betamax.util.message.*
+import co.freeside.betamax.util.message.BasicRequest
+import co.freeside.betamax.util.message.BasicResponse
 import com.google.common.io.Files
-import com.google.common.net.MediaType
 import spock.lang.*
+
 import static co.freeside.betamax.TapeMode.READ_WRITE
 import static co.freeside.betamax.tape.EntityStorage.external
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE
-import static com.google.common.net.MediaType.JSON_UTF_8
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8
-import static com.google.common.net.MediaType.PNG
+import static com.google.common.net.MediaType.*
 import static java.net.HttpURLConnection.HTTP_OK
 
 @Issue("https://github.com/robfletcher/betamax/issues/59")
@@ -101,7 +99,7 @@ class ExternalBodySpec extends Specification {
         body1 != body2
     }
 
-    void "if a response is overwritten the body file is re-used"() {
+    void "if a response is overwritten the body filename is re-used"() {
         given: "the tape is set to record response bodies externally"
         tape.responseBodyStorage = external
 

--- a/betamax-core/src/test/groovy/co/freeside/betamax/tape/WriteTapeToYamlSpec.groovy
+++ b/betamax-core/src/test/groovy/co/freeside/betamax/tape/WriteTapeToYamlSpec.groovy
@@ -23,6 +23,7 @@ import com.google.common.io.Files
 import org.yaml.snakeyaml.Yaml
 import spock.lang.*
 import static co.freeside.betamax.TapeMode.READ_WRITE
+import static com.google.common.net.MediaType.FORM_DATA
 import static java.net.HttpURLConnection.*
 import static com.google.common.net.HttpHeaders.*
 
@@ -46,6 +47,7 @@ class WriteTapeToYamlSpec extends Specification {
         getRequest.addHeader(IF_NONE_MATCH, "b00b135")
 
         postRequest = new BasicRequest("POST", "http://github.com/")
+        postRequest.addHeader(CONTENT_TYPE, FORM_DATA.toString())
         postRequest.body = "q=1".bytes
 
         successResponse = new BasicResponse(HTTP_OK, "OK")

--- a/betamax-proxy/src/main/java/co/freeside/betamax/proxy/netty/NettyMessageAdapter.java
+++ b/betamax-proxy/src/main/java/co/freeside/betamax/proxy/netty/NettyMessageAdapter.java
@@ -16,13 +16,14 @@
 
 package co.freeside.betamax.proxy.netty;
 
-import java.io.*;
-import java.util.Map;
 import co.freeside.betamax.message.AbstractMessage;
 import com.google.common.base.Joiner;
 import com.google.common.collect.*;
 import io.netty.buffer.*;
 import io.netty.handler.codec.http.*;
+import java.io.*;
+import java.util.Map;
+
 import static io.netty.buffer.Unpooled.copiedBuffer;
 
 public abstract class NettyMessageAdapter<T extends HttpMessage> extends AbstractMessage {
@@ -84,4 +85,5 @@ public abstract class NettyMessageAdapter<T extends HttpMessage> extends Abstrac
         //Copy the body into a new ByteBuf so that it can be consumed multiple times.
         return new ByteBufInputStream(Unpooled.copiedBuffer(body));
     }
+
 }


### PR DESCRIPTION
Add test for binary POST requests.

    * Currently fails (MemoryTape assumes all POST bodies are text and
        decodes their byte[]s as UTF8).

Binary POST body support.