### PR TITLE
Add option to enable authentication on the Betamax proxy.

### DIFF
--- a/betamax-core/src/main/java/software/betamax/ProxyConfiguration.java
+++ b/betamax-core/src/main/java/software/betamax/ProxyConfiguration.java
@@ -35,6 +35,8 @@ public class ProxyConfiguration extends Configuration {
 
     private final String proxyHost;
     private final int proxyPort;
+    private final String proxyUser;
+    private final String proxyPassword;
     private final int proxyTimeoutSeconds;
     private final boolean sslEnabled;
     private final int requestBufferSize;
@@ -43,6 +45,8 @@ public class ProxyConfiguration extends Configuration {
         super(builder);
         this.proxyHost = builder.proxyHost;
         this.proxyPort = builder.proxyPort;
+        this.proxyUser = builder.proxyUser;
+        this.proxyPassword = builder.proxyPassword;
         this.proxyTimeoutSeconds = builder.proxyTimeoutSeconds;
         this.sslEnabled = builder.sslEnabled;
         this.requestBufferSize = builder.requestBufferSize;
@@ -97,6 +101,20 @@ public class ProxyConfiguration extends Configuration {
         } catch (UnknownHostException e) {
             throw new ProxyConfigurationException(String.format("Unable to resolve host %s", proxyHost), e);
         }
+    }
+
+    /**
+     * The username required to authenticate with the proxy.
+     */
+    public String getProxyUser() {
+        return proxyUser;
+    }
+
+    /**
+     * The password required to authenticate with the proxy.
+     */
+    public String getProxyPassword() {
+        return proxyPassword;
     }
 
     /**

--- a/betamax-core/src/main/java/software/betamax/ProxyConfigurationBuilder.java
+++ b/betamax-core/src/main/java/software/betamax/ProxyConfigurationBuilder.java
@@ -29,6 +29,8 @@ public abstract class ProxyConfigurationBuilder<T extends ProxyConfigurationBuil
 
     protected String proxyHost = ProxyConfiguration.DEFAULT_PROXY_HOST;
     protected int proxyPort = ProxyConfiguration.DEFAULT_PROXY_PORT;
+    protected String proxyUser;
+    protected String proxyPassword;
     protected int proxyTimeoutSeconds = ProxyConfiguration.DEFAULT_PROXY_TIMEOUT;
     protected int requestBufferSize = ProxyConfiguration.DEFAULT_REQUEST_BUFFER_SIZE;
     protected boolean sslEnabled;
@@ -67,6 +69,16 @@ public abstract class ProxyConfigurationBuilder<T extends ProxyConfigurationBuil
 
     public T proxyPort(int proxyPort) {
         this.proxyPort = proxyPort;
+        return self();
+    }
+
+    public T proxyAuth(String username, String password) {
+        if (username == null || password == null) {
+            throw new IllegalArgumentException("The required proxy username and password cannot be null");
+        }
+
+        this.proxyUser = username;
+        this.proxyPassword = password;
         return self();
     }
 

--- a/betamax-core/src/main/java/software/betamax/proxy/ProxyServer.java
+++ b/betamax-core/src/main/java/software/betamax/proxy/ProxyServer.java
@@ -16,6 +16,7 @@
 
 package software.betamax.proxy;
 
+import org.littleshoot.proxy.*;
 import software.betamax.ProxyConfiguration;
 import software.betamax.internal.RecorderListener;
 import software.betamax.proxy.netty.PredicatedHttpFilters;
@@ -24,10 +25,6 @@ import software.betamax.util.ProxyOverrider;
 import software.betamax.util.SSLOverrider;
 import com.google.common.base.Predicate;
 import io.netty.handler.codec.http.HttpRequest;
-import org.littleshoot.proxy.HttpFilters;
-import org.littleshoot.proxy.HttpFiltersSourceAdapter;
-import org.littleshoot.proxy.HttpProxyServer;
-import org.littleshoot.proxy.HttpProxyServerBootstrap;
 import org.littleshoot.proxy.extras.SelfSignedMitmManager;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
@@ -89,6 +86,16 @@ public class ProxyServer implements RecorderListener {
             proxyServerBootstrap.withManInTheMiddle(new SelfSignedMitmManager());
         } else {
             proxyServerBootstrap.withChainProxyManager(proxyOverrider);
+        }
+
+        if (configuration.getProxyUser() != null) {
+            proxyServerBootstrap.withProxyAuthenticator(new ProxyAuthenticator() {
+                @Override
+                public boolean authenticate(String userName, String password) {
+                    return configuration.getProxyUser().equals(userName)
+                            && configuration.getProxyPassword().equals(password);
+                }
+            });
         }
 
         proxyServerBootstrap.withFiltersSource(new HttpFiltersSourceAdapter() {

--- a/betamax-tests/src/test/groovy/software/betamax/proxy/ProxyAuthenticationSpec.groovy
+++ b/betamax-tests/src/test/groovy/software/betamax/proxy/ProxyAuthenticationSpec.groovy
@@ -29,10 +29,10 @@ import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 
-import static software.betamax.TapeMode.READ_WRITE
+import static software.betamax.TapeMode.READ_ONLY
 
 @Issue("https://github.com/betamaxteam/betamax/issues/174")
-@Betamax(mode = READ_WRITE)
+@Betamax(mode = READ_ONLY)
 class ProxyAuthenticationSpec extends Specification {
     static final String PROXY_USERNAME = "dummy"
     static final String PROXY_PASSWORD = "password"

--- a/betamax-tests/src/test/groovy/software/betamax/proxy/ProxyAuthenticationSpec.groovy
+++ b/betamax-tests/src/test/groovy/software/betamax/proxy/ProxyAuthenticationSpec.groovy
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.betamax.proxy
+
+import com.google.common.io.Files
+import java.net.Authenticator.RequestorType
+import org.junit.ClassRule
+import software.betamax.ProxyConfiguration
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
+import software.betamax.util.server.EchoHandler
+import software.betamax.util.server.SimpleServer
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+import static software.betamax.TapeMode.READ_WRITE
+
+@Issue("https://github.com/betamaxteam/betamax/issues/174")
+@Betamax(mode = READ_WRITE)
+class ProxyAuthenticationSpec extends Specification {
+    static final String PROXY_USERNAME = "dummy"
+    static final String PROXY_PASSWORD = "password"
+
+    @Shared @AutoCleanup("deleteDir") def tapeRoot = Files.createTempDir()
+    @Shared def configuration = ProxyConfiguration.builder().
+            proxyAuth(PROXY_USERNAME, PROXY_PASSWORD).
+            tapeRoot(tapeRoot).build()
+    @Shared @ClassRule RecorderRule recorder = new RecorderRule(configuration)
+
+    @AutoCleanup("stop") def endpoint = new SimpleServer(EchoHandler)
+
+    String oldProxyUser
+    String oldProxyPassword
+    Authenticator oldAuthenticator
+
+    void setup() {
+        oldProxyUser = System.getProperty("http.proxyUser")
+        oldProxyPassword = System.getProperty("http.proxyPassword")
+        Authenticator.setDefault(new ProxyAuthenticator())
+        CookieHandler.setDefault(new CookieManager(null, CookiePolicy.ACCEPT_ALL))
+    }
+
+    void cleanup() {
+        if (oldProxyUser != null) System.setProperty("http.proxyUser", oldProxyUser)
+        else System.clearProperty("http.proxyUser")
+
+        if (oldProxyPassword != null) System.setProperty("http.proxyPassword", oldProxyPassword)
+        else System.clearProperty("http.proxyPassword")
+
+        Authenticator.setDefault(null)
+    }
+
+    void "proxy responds with 407 if proxy credentials are not provided"() {
+        given:
+        endpoint.start()
+
+        when:
+        HttpURLConnection connection = endpoint.url.toURL().openConnection()
+        def status = connection.responseCode
+
+        then:
+        status == 407
+    }
+
+    void "proxy responds with 407 if proxy credentials are incorrect"() {
+        given:
+        endpoint.start()
+
+        and: "Proxy invalid authentication settings"
+        System.setProperty("http.proxyUser", PROXY_USERNAME)
+        System.setProperty("http.proxyPassword", "kdsfjgnask")
+        System.setProperty("http.maxRedirects", "3")
+
+        when:
+        HttpURLConnection connection = endpoint.url.toURL().openConnection()
+        def status = connection.responseCode
+
+        then:
+        status == 407
+    }
+
+    void "proxy forwards the request if proxy credentials are correct"() {
+        given:
+        endpoint.start()
+
+        and: "Proxy valid authentication settings"
+        System.setProperty("http.proxyUser", PROXY_USERNAME)
+        System.setProperty("http.proxyPassword", PROXY_PASSWORD)
+
+        when:
+        HttpURLConnection connection = endpoint.url.toURL().openConnection()
+        def status = connection.responseCode
+
+        then:
+        status == 200
+    }
+
+    private static class ProxyAuthenticator extends Authenticator {
+        @Override
+        protected PasswordAuthentication getPasswordAuthentication() {
+            if (requestorType == RequestorType.PROXY && System.getProperty("http.proxyUser") != null) {
+                return new PasswordAuthentication(
+                        System.getProperty("http.proxyUser"),
+                        System.getProperty("http.proxyPassword")?.toCharArray() ?: new char[0])
+            }
+
+            return null
+        }
+    }
+
+}


### PR DESCRIPTION
Implements issue #174. The `ProxyConfiguration` now has a `proxyAuth()` method
that configures the username and password that the LittleProxy server will
require to accept connections. It's a convenience for any tool that uses Betamax
for testing and also wants to verify that its proxy support fully works. It
has no direct bearing on how Betamax itself operates.