### PR TITLE
Start ProxyServer once for each test class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/
 lib/
 log.txt
 target/
+littleproxy_cert

--- a/betamax-core/src/main/java/software/betamax/ConfigurationBuilder.java
+++ b/betamax-core/src/main/java/software/betamax/ConfigurationBuilder.java
@@ -92,6 +92,16 @@ public abstract class ConfigurationBuilder<T extends ConfigurationBuilder<T>> {
         return self();
     }
 
+    public T withConfig(final Configuration configuration) {
+        tapeRoot(configuration.getTapeRoot());
+        defaultMode(configuration.getDefaultMode());
+        defaultMatchRule(configuration.getDefaultMatchRule());
+        ignoreHosts(configuration.getIgnoreHosts());
+        ignoreLocalhost(configuration.isIgnoreLocalhost());
+
+        return self();
+    }
+
     public T tapeRoot(File tapeRoot) {
         this.tapeRoot = tapeRoot;
         return self();

--- a/betamax-core/src/main/java/software/betamax/MatchRules.java
+++ b/betamax-core/src/main/java/software/betamax/MatchRules.java
@@ -26,47 +26,52 @@ import java.util.Arrays;
 public enum MatchRules implements MatchRule {
     method {
         @Override
-        public boolean isMatch(Request a, Request b) {
+        public boolean isMatch(final Request a, final Request b) {
             return a.getMethod().equalsIgnoreCase(b.getMethod());
         }
     }, uri {
         @Override
-        public boolean isMatch(Request a, Request b) {
+        public boolean isMatch(final Request a, final Request b) {
             return a.getUri().equals(b.getUri());
         }
     }, host {
         @Override
-        public boolean isMatch(Request a, Request b) {
+        public boolean isMatch(final Request a, final Request b) {
             return a.getUri().getHost().equals(b.getUri().getHost());
         }
     }, path {
         @Override
-        public boolean isMatch(Request a, Request b) {
+        public boolean isMatch(final Request a, final Request b) {
             return a.getUri().getPath().equals(b.getUri().getPath());
         }
     }, port {
         @Override
-        public boolean isMatch(Request a, Request b) {
+        public boolean isMatch(final Request a, final Request b) {
             return a.getUri().getPort() == b.getUri().getPort();
         }
     }, query {
         @Override
-        public boolean isMatch(Request a, Request b) {
+        public boolean isMatch(final Request a, final Request b) {
             return a.getUri().getQuery().equals(b.getUri().getQuery());
         }
     }, authorization {
         @Override
-        public boolean isMatch(Request a, Request b) {
+        public boolean isMatch(final Request a, final Request b) {
             return a.getHeader("Authorization").equals(b.getHeader("Authorization"));
         }
     }, accept {
         @Override
-        public boolean isMatch(Request a, Request b) {
+        public boolean isMatch(final Request a, final Request b) {
             return a.getHeader("Accept").equals(b.getHeader("Accept"));
+        }
+    }, contentType {
+        @Override
+        public boolean isMatch(final Request a, final Request b) {
+            return a.getHeader("Content-Type").equals(b.getHeader("Content-Type"));
         }
     }, body {
         @Override
-        public boolean isMatch(Request a, Request b) {
+        public boolean isMatch(final Request a, final Request b) {
             return Arrays.equals(a.getBodyAsBinary(), b.getBodyAsBinary());
         }
     }

--- a/betamax-core/src/main/java/software/betamax/ProxyConfigurationBuilder.java
+++ b/betamax-core/src/main/java/software/betamax/ProxyConfigurationBuilder.java
@@ -22,7 +22,6 @@ import java.util.Properties;
 
 public abstract class ProxyConfigurationBuilder<T extends ProxyConfigurationBuilder<T>> extends ConfigurationBuilder<T> {
 
-
     public ProxyConfiguration build() {
         return new ProxyConfiguration(this);
     }
@@ -34,6 +33,7 @@ public abstract class ProxyConfigurationBuilder<T extends ProxyConfigurationBuil
     protected int proxyTimeoutSeconds = ProxyConfiguration.DEFAULT_PROXY_TIMEOUT;
     protected int requestBufferSize = ProxyConfiguration.DEFAULT_REQUEST_BUFFER_SIZE;
     protected boolean sslEnabled;
+    protected boolean createProxyOnStartup = ProxyConfiguration.DEFAULT_CREATE_PROXY_ON_STARTUP;
 
     @Override
     public T withProperties(Properties properties) {
@@ -57,6 +57,31 @@ public abstract class ProxyConfigurationBuilder<T extends ProxyConfigurationBuil
 
         if (properties.containsKey("betamax.sslEnabled")) {
             sslEnabled(TypedProperties.getBoolean(properties, "betamax.sslEnabled"));
+        }
+
+        if (properties.containsKey("betamax.createProxyOnStartup")) {
+            createProxyOnStartup(TypedProperties.getBoolean(properties, "betamax.createProxyOnStartup"));
+        }
+
+        return self();
+    }
+
+    public T withConfig(final Configuration configuration) {
+        super.withConfig(configuration);
+
+        if (configuration instanceof ProxyConfiguration) {
+            final ProxyConfiguration proxyConfiguration = (ProxyConfiguration) configuration;
+
+            proxyHost(proxyConfiguration.getProxyHostname());
+            proxyPort(proxyConfiguration.getProxyPort());
+            proxyTimeoutSeconds(proxyConfiguration.getProxyTimeoutSeconds());
+            requestBufferSize(proxyConfiguration.getRequestBufferSize());
+            sslEnabled(proxyConfiguration.isSslEnabled());
+            createProxyOnStartup(proxyConfiguration.isCreateProxyOnStartup());
+
+            if (proxyConfiguration.getProxyUser() != null && proxyConfiguration.getProxyPassword() != null) {
+                proxyAuth(proxyConfiguration.getProxyUser(), proxyConfiguration.getProxyPassword());
+            }
         }
 
         return self();
@@ -87,13 +112,18 @@ public abstract class ProxyConfigurationBuilder<T extends ProxyConfigurationBuil
         return self();
     }
 
-    public T requestBufferSize(int requestBufferSize){
+    public T requestBufferSize(int requestBufferSize) {
         this.requestBufferSize = requestBufferSize;
         return self();
     }
 
     public T sslEnabled(boolean sslEnabled) {
         this.sslEnabled = sslEnabled;
+        return self();
+    }
+
+    public T createProxyOnStartup(boolean createProxyOnStartup) {
+        this.createProxyOnStartup = createProxyOnStartup;
         return self();
     }
 }

--- a/betamax-core/src/main/java/software/betamax/Recorder.java
+++ b/betamax-core/src/main/java/software/betamax/Recorder.java
@@ -34,6 +34,8 @@ public class Recorder {
     private final Configuration configuration;
     private final Collection<RecorderListener> listeners = Lists.newArrayList();
 
+    private Tape tape;
+
     public Recorder() {
         this(ProxyConfiguration.builder().build());
     }
@@ -46,10 +48,9 @@ public class Recorder {
     /**
      * Starts the Recorder, inserting a tape with the specified parameters.
      *
-     * @param tapeName the name of the tape.
-     * @param mode the tape mode. If not supplied the default mode from the configuration is used.
+     * @param tapeName  the name of the tape.
+     * @param mode      the tape mode. If not supplied the default mode from the configuration is used.
      * @param matchRule the rules used to match recordings on the tape. If not supplied a default is used.
-     *
      * @throws IllegalStateException if the Recorder is already started.
      */
     public void start(String tapeName, Optional<TapeMode> mode, Optional<MatchRule> matchRule) {
@@ -91,8 +92,17 @@ public class Recorder {
         for (RecorderListener listener : listeners) {
             listener.onRecorderStop();
         }
+
         getTapeLoader().writeTape(tape);
         tape = null;
+    }
+
+    public void addListener(final RecorderListener recorderListener) {
+        listeners.add(recorderListener);
+    }
+
+    public void removeListener(final RecorderListener recorderListener) {
+        listeners.remove(recorderListener);
     }
 
     /**
@@ -104,12 +114,14 @@ public class Recorder {
         return tape;
     }
 
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
     /**
      * Not just a property as `tapeRoot` gets changed during constructor.
      */
-    private TapeLoader<? extends Tape> getTapeLoader() {
+    protected TapeLoader<? extends Tape> getTapeLoader() {
         return new YamlTapeLoader(configuration.getTapeRoot());
     }
-
-    private Tape tape;
 }

--- a/betamax-core/src/main/java/software/betamax/Recorder.java
+++ b/betamax-core/src/main/java/software/betamax/Recorder.java
@@ -40,7 +40,7 @@ public class Recorder {
         this(ProxyConfiguration.builder().build());
     }
 
-    public Recorder(Configuration configuration) {
+    public Recorder(final Configuration configuration) {
         this.configuration = configuration;
         configuration.registerListeners(listeners);
     }
@@ -53,7 +53,7 @@ public class Recorder {
      * @param matchRule the rules used to match recordings on the tape. If not supplied a default is used.
      * @throws IllegalStateException if the Recorder is already started.
      */
-    public void start(String tapeName, Optional<TapeMode> mode, Optional<MatchRule> matchRule) {
+    public void start(final String tapeName, final Optional<TapeMode> mode, final Optional<MatchRule> matchRule) {
         if (tape != null) {
             throw new IllegalStateException("start called when Recorder is already started");
         }
@@ -67,15 +67,15 @@ public class Recorder {
         }
     }
 
-    public void start(String tapeName, TapeMode mode, MatchRule matchRule) {
-        start(tapeName, mode.toOptional(), Optional.<MatchRule>of(matchRule));
+    public void start(final String tapeName, final TapeMode mode, final MatchRule matchRule) {
+        start(tapeName, mode.toOptional(), Optional.of(matchRule));
     }
 
-    public void start(String tapeName, TapeMode mode) {
+    public void start(final String tapeName, final TapeMode mode) {
         start(tapeName, mode.toOptional(), Optional.<MatchRule>absent());
     }
 
-    public void start(String tapeName) {
+    public void start(final String tapeName) {
         start(tapeName, Optional.<TapeMode>absent(), Optional.<MatchRule>absent());
     }
 

--- a/betamax-core/src/main/java/software/betamax/TapeMode.java
+++ b/betamax-core/src/main/java/software/betamax/TapeMode.java
@@ -23,7 +23,8 @@ public enum TapeMode {
     READ_ONLY(true, false, false),
     READ_SEQUENTIAL(true, false, true),
     WRITE_ONLY(false, true, false),
-    WRITE_SEQUENTIAL(false, true, true);
+    WRITE_SEQUENTIAL(false, true, true),
+    UNDEFINED(false, false, false);
 
     private final boolean readable;
     private final boolean writable;
@@ -55,7 +56,11 @@ public enum TapeMode {
     }
 
     public Optional<TapeMode> toOptional() {
-        return Optional.of(this);
+        switch(this) {
+            case UNDEFINED:
+                return Optional.absent();
+            default:
+                return Optional.of(this);
+        }
     }
-
 }

--- a/betamax-core/src/main/java/software/betamax/proxy/ProxyServer.java
+++ b/betamax-core/src/main/java/software/betamax/proxy/ProxyServer.java
@@ -118,8 +118,6 @@ public class ProxyServer implements RecorderListener, TapeProvider {
     }
 
     public void stop() {
-        this.currentTape = null;
-
         if (configuration.isCreateProxyOnStartup() && isRunning()) {
             stopServer();
         }

--- a/betamax-core/src/main/java/software/betamax/proxy/ProxyServer.java
+++ b/betamax-core/src/main/java/software/betamax/proxy/ProxyServer.java
@@ -77,6 +77,14 @@ public class ProxyServer implements RecorderListener, TapeProvider {
         return running;
     }
 
+    public String getHostName() {
+        return proxyServer.getListenAddress().getHostName();
+    }
+
+    public int getPort() {
+        return proxyServer.getListenAddress().getPort();
+    }
+
     public void start() {
         if (isRunning()) {
             throw new IllegalStateException("Betamax proxy server is already running");
@@ -118,7 +126,7 @@ public class ProxyServer implements RecorderListener, TapeProvider {
     }
 
     private void overrideProxySettings() {
-        proxyOverrider.activate(configuration.getProxyHost(), configuration.getProxyPort(), configuration.getIgnoreHosts());
+        proxyOverrider.activate(configuration.getProxyHost(), getPort(), configuration.getIgnoreHosts());
     }
 
     private void restoreOriginalProxySettings() {

--- a/betamax-core/src/main/java/software/betamax/proxy/TapeProvider.java
+++ b/betamax-core/src/main/java/software/betamax/proxy/TapeProvider.java
@@ -1,7 +1,26 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.betamax.proxy;
 
 import software.betamax.tape.Tape;
 
+/**
+ * A simple provider interface for dynamically loading the current tape available to the proxy filter.
+ */
 public interface TapeProvider {
 
     Tape getTape();

--- a/betamax-core/src/main/java/software/betamax/proxy/TapeProvider.java
+++ b/betamax-core/src/main/java/software/betamax/proxy/TapeProvider.java
@@ -1,0 +1,8 @@
+package software.betamax.proxy;
+
+import software.betamax.tape.Tape;
+
+public interface TapeProvider {
+
+    Tape getTape();
+}

--- a/betamax-junit/src/main/java/software/betamax/junit/Betamax.java
+++ b/betamax-junit/src/main/java/software/betamax/junit/Betamax.java
@@ -30,7 +30,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface Betamax {
     String tape() default "";
 
-    TapeMode mode() default TapeMode.READ_ONLY;
+    TapeMode mode() default TapeMode.UNDEFINED;
 
     MatchRules[] match() default {MatchRules.method, MatchRules.uri};
 }

--- a/betamax-junit/src/main/java/software/betamax/junit/ProxyServerResource.java
+++ b/betamax-junit/src/main/java/software/betamax/junit/ProxyServerResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.betamax.junit;
 
 import org.junit.rules.ExternalResource;

--- a/betamax-junit/src/main/java/software/betamax/junit/ProxyServerResource.java
+++ b/betamax-junit/src/main/java/software/betamax/junit/ProxyServerResource.java
@@ -1,0 +1,23 @@
+package software.betamax.junit;
+
+import org.junit.rules.ExternalResource;
+import software.betamax.proxy.ProxyServer;
+
+public class ProxyServerResource extends ExternalResource {
+
+    private final ProxyServer proxyServer;
+
+    public ProxyServerResource(final ProxyServer proxyServer) {
+        this.proxyServer = proxyServer;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        proxyServer.start();
+    }
+
+    @Override
+    protected void after() {
+        proxyServer.stopServer();
+    }
+}

--- a/betamax-junit/src/main/java/software/betamax/junit/RecorderResource.java
+++ b/betamax-junit/src/main/java/software/betamax/junit/RecorderResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.betamax.junit;
 
 import com.google.common.base.Strings;
@@ -16,7 +32,7 @@ import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 
 public class RecorderResource extends ExternalResource {
 
-    private static final Logger log = Logger.getLogger(RecorderResource.class.getName());
+    private static final Logger LOG = Logger.getLogger(RecorderResource.class.getName());
 
     private final Description description;
     private final Recorder recorder;
@@ -32,11 +48,11 @@ public class RecorderResource extends ExternalResource {
 
         final Betamax annotation = description.getAnnotation(Betamax.class);
         if (annotation == null) {
-            log.fine(String.format("no @Betamax annotation on '%s'", description.getDisplayName()));
+            LOG.fine(String.format("no @Betamax annotation on '%s'", description.getDisplayName()));
             return;
         }
 
-        log.fine(String.format("found @Betamax annotation on '%s'", description.getDisplayName()));
+        LOG.fine(String.format("found @Betamax annotation on '%s'", description.getDisplayName()));
 
         String tapeName = annotation.tape();
         if (Strings.isNullOrEmpty(tapeName)) {

--- a/betamax-junit/src/main/java/software/betamax/junit/RecorderResource.java
+++ b/betamax-junit/src/main/java/software/betamax/junit/RecorderResource.java
@@ -1,0 +1,72 @@
+package software.betamax.junit;
+
+import com.google.common.base.Strings;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import software.betamax.ComposedMatchRule;
+import software.betamax.MatchRule;
+import software.betamax.Recorder;
+import software.betamax.TapeMode;
+
+import java.util.logging.Logger;
+
+import static com.google.common.base.CaseFormat.LOWER_CAMEL;
+import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
+import static com.google.common.base.CaseFormat.UPPER_CAMEL;
+
+public class RecorderResource extends ExternalResource {
+
+    private static final Logger log = Logger.getLogger(RecorderResource.class.getName());
+
+    private final Description description;
+    private final Recorder recorder;
+
+    public RecorderResource(final Description description,
+                            final Recorder recorder) {
+        this.description = description;
+        this.recorder = recorder;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+
+        final Betamax annotation = description.getAnnotation(Betamax.class);
+        if (annotation == null) {
+            log.fine(String.format("no @Betamax annotation on '%s'", description.getDisplayName()));
+            return;
+        }
+
+        log.fine(String.format("found @Betamax annotation on '%s'", description.getDisplayName()));
+
+        String tapeName = annotation.tape();
+        if (Strings.isNullOrEmpty(tapeName)) {
+            tapeName = defaultTapeName(description);
+        }
+
+        final TapeMode tapeMode = annotation.mode();
+        final MatchRule matchRule = ComposedMatchRule.of(annotation.match());
+
+        recorder.start(tapeName, tapeMode, matchRule);
+    }
+
+    @Override
+    protected void after() {
+
+        // don't stop the recorder if there was no annotation on the class or method
+        final Betamax annotation = description.getAnnotation(Betamax.class);
+        if (annotation != null) {
+            recorder.stop();
+        }
+    }
+
+    protected String defaultTapeName(final Description description) {
+        String name;
+        if (description.getMethodName() != null) {
+            name = LOWER_CAMEL.to(LOWER_UNDERSCORE, description.getMethodName());
+        } else {
+            name = UPPER_CAMEL.to(LOWER_UNDERSCORE, description.getTestClass().getSimpleName());
+        }
+
+        return name.replace('_', ' ');
+    }
+}

--- a/betamax-junit/src/main/java/software/betamax/junit/RecorderRule.java
+++ b/betamax-junit/src/main/java/software/betamax/junit/RecorderRule.java
@@ -83,4 +83,8 @@ public class RecorderRule implements TestRule {
     public Configuration getConfiguration() {
         return recorder.getConfiguration();
     }
+
+    public int getListenPort() {
+        return proxyServer.getPort();
+    }
 }

--- a/betamax-tests/betamax-tests.gradle
+++ b/betamax-tests/betamax-tests.gradle
@@ -26,4 +26,5 @@ dependencies {
     testCompile "com.github.groovy-wslite:groovy-wslite:0.8.0"
 
     testCompile "com.mashape.unirest:unirest-java:1.2.8", "org.apache.httpcomponents:httpasyncclient:4.0"
+    testCompile "org.slf4j:slf4j-jdk14:1.7.12"
 }

--- a/betamax-tests/src/test/groovy/software/betamax/SharedRecorderSpec.groovy
+++ b/betamax-tests/src/test/groovy/software/betamax/SharedRecorderSpec.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.betamax
+
+import com.google.common.io.BaseEncoding
+import com.google.common.io.Files
+import org.junit.ClassRule
+import org.junit.Rule
+import software.betamax.junit.Betamax
+import software.betamax.junit.RecorderRule
+import spock.lang.*
+
+import static Headers.X_BETAMAX
+import static java.net.HttpURLConnection.HTTP_OK
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED
+import static java.util.concurrent.TimeUnit.SECONDS
+import static software.betamax.MatchRules.*
+import static software.betamax.TapeMode.READ_ONLY
+import static software.betamax.TapeMode.WRITE_ONLY
+
+@Unroll
+@Stepwise
+@IgnoreIf({
+    def url = "http://httpbin.org/".toURL()
+    try {
+        HttpURLConnection connection = url.openConnection() as HttpURLConnection
+        connection.requestMethod = "HEAD"
+        connection.connectTimeout = SECONDS.toMillis(2)
+        connection.connect()
+        return connection.responseCode >= 400
+    } catch (IOException e) {
+        System.err.println "Skipping spec as $url is not available: $e.message"
+        return true
+    }
+})
+class SharedRecorderSpec extends Specification {
+
+    @Shared private endpoint = "http://httpbin.org/basic-auth/user/passwd".toURL()
+
+    @Shared @AutoCleanup("deleteDir") def tapeRoot = Files.createTempDir()
+    @Shared def configuration = ProxyConfiguration.builder().tapeRoot(tapeRoot).build()
+
+    @Shared @ClassRule RecorderRule sharedRecorder = new RecorderRule(configuration)
+    @Rule RecorderRule recorder = sharedRecorder
+
+    @Betamax(tape = "basic auth", mode = WRITE_ONLY, match = [method, uri, authorization])
+    void "can record #status response from authenticated endpoint"() {
+        when:
+        HttpURLConnection connection = endpoint.openConnection() as HttpURLConnection
+        connection.setRequestProperty("Authorization", "Basic $credentials");
+
+        then:
+        connection.responseCode == status
+        connection.getHeaderField(X_BETAMAX) == "REC"
+
+        where:
+        password    | status
+        "passwd"    | HTTP_OK
+        "INCORRECT" | HTTP_UNAUTHORIZED
+
+        credentials = BaseEncoding.base64().encode("user:$password".bytes)
+    }
+
+    @Betamax(tape = "basic auth", mode = READ_ONLY, match = [method, uri, authorization])
+    void "can play back #status response from authenticated endpoint"() {
+        when:
+        HttpURLConnection connection = endpoint.openConnection() as HttpURLConnection
+        connection.setRequestProperty("Authorization", "Basic $credentials");
+
+        then:
+        connection.responseCode == status
+        connection.getHeaderField(X_BETAMAX) == "PLAY"
+
+        where:
+        password    | status
+        "passwd"    | HTTP_OK
+        "INCORRECT" | HTTP_UNAUTHORIZED
+
+        credentials = BaseEncoding.base64().encode("user:$password".bytes)
+    }
+}

--- a/betamax-tests/src/test/groovy/software/betamax/proxy/BetamaxFiltersSpec.groovy
+++ b/betamax-tests/src/test/groovy/software/betamax/proxy/BetamaxFiltersSpec.groovy
@@ -16,27 +16,29 @@
 
 package software.betamax.proxy
 
+import com.google.common.io.ByteStreams
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.ByteBufInputStream
+import io.netty.handler.codec.http.*
 import software.betamax.encoding.DeflateEncoder
 import software.betamax.encoding.GzipEncoder
-import software.betamax.message.Response
 import software.betamax.encoding.NoOpEncoder
 import software.betamax.message.Request
-
-import java.nio.charset.Charset
-import software.betamax.encoding.*
-import software.betamax.message.*
+import software.betamax.message.Response
 import software.betamax.tape.Tape
 import software.betamax.util.message.BasicResponse
-import com.google.common.io.ByteStreams
-import io.netty.buffer.*
-import io.netty.handler.codec.http.*
-import spock.lang.*
-import static software.betamax.Headers.X_BETAMAX
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.nio.charset.Charset
+
 import static io.netty.buffer.Unpooled.copiedBuffer
-import static io.netty.handler.codec.http.HttpHeaders.Names.*
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_ENCODING
 import static io.netty.handler.codec.http.HttpMethod.GET
 import static io.netty.handler.codec.http.HttpResponseStatus.OK
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1
+import static software.betamax.Headers.X_BETAMAX
 
 @Unroll
 class BetamaxFiltersSpec extends Specification {
@@ -47,7 +49,7 @@ class BetamaxFiltersSpec extends Specification {
 	Tape tape = Mock(Tape)
 
 	void setup() {
-		filters = new BetamaxFilters(request, tape)
+		filters = new BetamaxFilters(request, [getTape: { tape }] as TapeProvider)
 	}
 
 	void "clientToProxyRequest returns null if no match is found on tape"() {

--- a/betamax-tests/src/test/java/software/betamax/junit/StartupProxyOnceTest.java
+++ b/betamax-tests/src/test/java/software/betamax/junit/StartupProxyOnceTest.java
@@ -1,31 +1,66 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.betamax.junit;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import software.betamax.ProxyConfiguration;
+import software.betamax.TapeMode;
 
 public class StartupProxyOnceTest {
 
     @Rule
     @ClassRule
-    public static RecorderRule recorder = new RecorderRule(ProxyConfiguration.builder().proxyPort(0).build());
+    public static RecorderRule recorder = new RecorderRule(ProxyConfiguration.builder()
+            .defaultMode(TapeMode.WRITE_SEQUENTIAL)
+            .proxyPort(0)
+            .build());
 
     @Test
     @Betamax(tape = "test1")
     public void firstTest() {
         assert recorder.getTape().getName().equals("test1");
+        assert recorder.getTape().getMode() == TapeMode.WRITE_SEQUENTIAL;
+
+        assert recorder.getListenPort() > 0;
+        assert System.getProperty("http.proxyPort").equals(Integer.toString(recorder.getListenPort()));
+        assert System.getProperty("https.proxyPort").equals(Integer.toString(recorder.getListenPort()));
     }
 
     @Test
-    @Betamax(tape = "test2")
+    @Betamax(tape = "test2", mode = TapeMode.READ_SEQUENTIAL)
     public void secondTest() {
         assert recorder.getTape().getName().equals("test2");
+        assert recorder.getTape().getMode() == TapeMode.READ_SEQUENTIAL;
+
+        assert recorder.getListenPort() > 0;
+        assert System.getProperty("http.proxyPort").equals(Integer.toString(recorder.getListenPort()));
+        assert System.getProperty("https.proxyPort").equals(Integer.toString(recorder.getListenPort()));
     }
 
     @Test
     @Betamax(tape = "test3")
     public void thirdTest() {
         assert recorder.getTape().getName().equals("test3");
+        assert recorder.getTape().getMode() == TapeMode.WRITE_SEQUENTIAL;
+
+        assert recorder.getListenPort() > 0;
+        assert System.getProperty("http.proxyPort").equals(Integer.toString(recorder.getListenPort()));
+        assert System.getProperty("https.proxyPort").equals(Integer.toString(recorder.getListenPort()));
     }
 }

--- a/betamax-tests/src/test/java/software/betamax/junit/StartupProxyOnceTest.java
+++ b/betamax-tests/src/test/java/software/betamax/junit/StartupProxyOnceTest.java
@@ -1,0 +1,31 @@
+package software.betamax.junit;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import software.betamax.ProxyConfiguration;
+
+public class StartupProxyOnceTest {
+
+    @Rule
+    @ClassRule
+    public static RecorderRule recorder = new RecorderRule(ProxyConfiguration.builder().proxyPort(0).build());
+
+    @Test
+    @Betamax(tape = "test1")
+    public void firstTest() {
+        assert recorder.getTape().getName().equals("test1");
+    }
+
+    @Test
+    @Betamax(tape = "test2")
+    public void secondTest() {
+        assert recorder.getTape().getName().equals("test2");
+    }
+
+    @Test
+    @Betamax(tape = "test3")
+    public void thirdTest() {
+        assert recorder.getTape().getName().equals("test3");
+    }
+}

--- a/example/play-framework-2.4.6-scala/test/resources/betamax.properties
+++ b/example/play-framework-2.4.6-scala/test/resources/betamax.properties
@@ -1,1 +1,0 @@
-betamax.tapeRoot=test/resources/betamax/tapes

--- a/example/play-framework-2.4.6-scala/test/software/betamax/BetamaxTest.scala
+++ b/example/play-framework-2.4.6-scala/test/software/betamax/BetamaxTest.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Await
   */
 class BetamaxTest extends Specification with DefaultAwaitTimeout {
   "A recorded interation" should {
-    "replay /" in RecordedInteraction("index", tapeMode = TapeMode.READ_WRITE) {
+    "replay /" in RecordedInteraction("index", tapeMode = TapeMode.READ_WRITE, tapeRoot = "test/resources/betamax/tapes") {
       val port = 3333
       new WithServer(port = port) {
         val response = Await.result(WS.url(s"http://localhost:$port").get(), defaultAwaitTimeout.duration)


### PR DESCRIPTION
When running this from a JUnit test class with both @ClassRule and @Rule, the RecorderRule separates out the concerns of starting the server and starting the recorder.  If running the recorder directly, the previous behavior is maintained; that is, it will automatically start the server.

A new configuration property was introduced to create the proxy on startup - it defaults to true, but is overridden by the JUnit rule startup.  Also, a TapeProvider interface was introduced to allow dynamic loading of tapes from the ProxyServer, so that each time a test method is run with a new Tape, it's retrieved correctly in the proxy routines.

There's also code to allow users to specify a proxyPort of '0' - when this happens, the actual port is looked up and attempted to be bound; if it fails, the process retries until it finds an open port.  The actual port is also sent into the proxyOverrider to set up the JDK proxy properties correctly; it used to always follow the config value, which is incorrect when '0' is used.

Lastly, a bug fix - when the ProxyConfiguration specified a default tape mode, it would be ignored because the @Betamax annotation specified a default already that would override it; I introduced an UNKNOWN tape mode that returns an Optional.absent().
