### PR TITLE
add queryParams MatchRule to be able to compare semantically equal but differently ordered querys

### DIFF
--- a/betamax-core/src/main/java/software/betamax/MatchRules.java
+++ b/betamax-core/src/main/java/software/betamax/MatchRules.java
@@ -54,6 +54,19 @@ public enum MatchRules implements MatchRule {
         public boolean isMatch(Request a, Request b) {
             return a.getUri().getQuery().equals(b.getUri().getQuery());
         }
+    },
+    /**
+     * Compare query parameters instead of query string representation.
+     */
+    queryParams {
+        @Override
+        public boolean isMatch(Request a, Request b) {
+            String[] aParameters = a.getUri().getQuery().split("&");
+            String[] bParameters = b.getUri().getQuery().split("&");
+            Arrays.sort(aParameters);
+            Arrays.sort(bParameters);
+            return Arrays.equals(aParameters, bParameters);
+        }
     }, authorization {
         @Override
         public boolean isMatch(Request a, Request b) {

--- a/betamax-tests/src/test/groovy/software/betamax/MatchRuleSpec.groovy
+++ b/betamax-tests/src/test/groovy/software/betamax/MatchRuleSpec.groovy
@@ -114,4 +114,19 @@ class MatchRuleSpec extends Specification {
         !rule.isMatch(request, request3)
     }
 
+    void 'can match query parameters in different orders'() {
+        given:
+        def request1 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax?p=2&q=1'.toURI())
+        def request2 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax?p=2&q=2'.toURI())
+
+        and:
+        def request = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax?q=1&p=2'.toURI())
+        def rule = ComposedMatchRule.of(method, queryParams)
+
+        expect:
+        rule.isMatch(request, request1)
+        !rule.isMatch(request, request2)
+
+    }
+
 }


### PR DESCRIPTION
Hi,

As outlined in #206. 
Comes with tests. 

What do you think?