### PR TITLE
fix queryParams match rule in case of empty query

### DIFF
--- a/betamax-core/src/main/java/software/betamax/MatchRules.java
+++ b/betamax-core/src/main/java/software/betamax/MatchRules.java
@@ -61,11 +61,20 @@ public enum MatchRules implements MatchRule {
     queryParams {
         @Override
         public boolean isMatch(Request a, Request b) {
-            String[] aParameters = a.getUri().getQuery().split("&");
-            String[] bParameters = b.getUri().getQuery().split("&");
-            Arrays.sort(aParameters);
-            Arrays.sort(bParameters);
-            return Arrays.equals(aParameters, bParameters);
+            if((a.getUri().getQuery() != null) && (b.getUri().getQuery() != null)) {
+                // both request have a query, split query params and compare
+                String[] aParameters = a.getUri().getQuery().split("&");
+                String[] bParameters = b.getUri().getQuery().split("&");
+                Arrays.sort(aParameters);
+                Arrays.sort(bParameters);
+                return Arrays.equals(aParameters, bParameters);
+            } else {
+                if ((a.getUri().getQuery() == null) && (b.getUri().getQuery() == null)) {
+                    // both request have no query
+                    return true;
+                }
+                return false;
+            }
         }
     }, authorization {
         @Override

--- a/betamax-tests/src/test/groovy/software/betamax/MatchRuleSpec.groovy
+++ b/betamax-tests/src/test/groovy/software/betamax/MatchRuleSpec.groovy
@@ -118,6 +118,8 @@ class MatchRuleSpec extends Specification {
         given:
         def request1 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax?p=2&q=1'.toURI())
         def request2 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax?p=2&q=2'.toURI())
+        def request3 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
+        def request4 = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax'.toURI())
 
         and:
         def request = new RecordedRequest(method: 'GET', uri: 'http://freeside.co/betamax?q=1&p=2'.toURI())
@@ -126,6 +128,8 @@ class MatchRuleSpec extends Specification {
         expect:
         rule.isMatch(request, request1)
         !rule.isMatch(request, request2)
+        rule.isMatch(request3, request4)
+        !rule.isMatch(request, request3)
 
     }
 


### PR DESCRIPTION
Added some more logic to address an issue when queryParams match rule is used with a request uri without a query.

Comes with tests.