### PR TITLE
Replace java.utils.logging with SLF4J

### DIFF
--- a/betamax-core/betamax-core.gradle
+++ b/betamax-core/betamax-core.gradle
@@ -11,4 +11,6 @@ dependencies {
     compile commonDependencies.tika
     compile commonDependencies.littleProxy
     compile commonDependencies.netty
+    compile commonDependencies.log4jCore
+    compile commonDependencies.log4jSlf4jImpl
 }

--- a/betamax-core/src/main/java/software/betamax/io/FileTypeMapper.java
+++ b/betamax-core/src/main/java/software/betamax/io/FileTypeMapper.java
@@ -18,8 +18,8 @@ package software.betamax.io;
 
 import org.apache.tika.mime.MimeTypeException;
 import org.apache.tika.mime.MimeTypes;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Maps _MIME_ types to file extensions.
@@ -34,7 +34,7 @@ public class FileTypeMapper {
 
     private static final MimeTypes MIME_TYPES = MimeTypes.getDefaultMimeTypes();
 
-    private static final Logger LOG = Logger.getLogger(FileTypeMapper.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(FileTypeMapper.class.getName());
 
     /**
      * Returns a filename consisting of `baseName` and an appropriate file
@@ -50,7 +50,7 @@ public class FileTypeMapper {
             String extension = MIME_TYPES.forName(contentType).getExtension();
             filename = baseName + extension;
         } catch (MimeTypeException e) {
-            LOG.warning(String.format("Could not get extension for %s content type: %s", contentType, e.getMessage()));
+            LOG.warn(String.format("Could not get extension for %s content type: %s", contentType, e.getMessage()));
             filename = baseName + DEFAULT_EXTENSION;
         }
         return filename;

--- a/betamax-core/src/main/java/software/betamax/proxy/ProxyServer.java
+++ b/betamax-core/src/main/java/software/betamax/proxy/ProxyServer.java
@@ -20,6 +20,8 @@ import com.google.common.base.Predicate;
 import io.netty.handler.codec.http.HttpRequest;
 import org.littleshoot.proxy.*;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.betamax.Configuration;
 import software.betamax.internal.RecorderListener;
 import software.betamax.proxy.netty.PredicatedHttpFilters;
@@ -28,7 +30,6 @@ import software.betamax.util.BetamaxMitmManager;
 import software.betamax.util.ProxyOverrider;
 
 import java.net.InetSocketAddress;
-import java.util.logging.Logger;
 
 import static com.google.common.base.Predicates.not;
 import static io.netty.handler.codec.http.HttpMethod.CONNECT;
@@ -43,7 +44,7 @@ public class ProxyServer implements RecorderListener {
 
     private static final Predicate<HttpRequest> NOT_CONNECT = not(httpMethodPredicate(CONNECT));
 
-    private static final Logger LOG = Logger.getLogger(ProxyServer.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(ProxyServer.class.getName());
 
     public ProxyServer(Configuration configuration) {
         this.configuration = configuration;

--- a/betamax-core/src/main/java/software/betamax/tape/yaml/YamlTapeLoader.java
+++ b/betamax-core/src/main/java/software/betamax/tape/yaml/YamlTapeLoader.java
@@ -18,6 +18,8 @@ package software.betamax.tape.yaml;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Files;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
@@ -33,7 +35,6 @@ import software.betamax.tape.TapeLoader;
 
 import java.io.*;
 import java.nio.charset.Charset;
-import java.util.logging.Logger;
 
 import static org.yaml.snakeyaml.DumperOptions.FlowStyle.BLOCK;
 
@@ -43,7 +44,7 @@ public class YamlTapeLoader implements TapeLoader<YamlTape> {
 
     private final FileResolver fileResolver;
 
-    private static final Logger LOG = Logger.getLogger(YamlTapeLoader.class.getName());
+    private static final Logger LOG = LoggerFactory.getLogger(YamlTapeLoader.class.getName());
 
     public YamlTapeLoader(File tapeRoot) {
         fileResolver = new FileResolver(tapeRoot);

--- a/betamax-junit/src/main/java/software/betamax/junit/RecorderRule.java
+++ b/betamax-junit/src/main/java/software/betamax/junit/RecorderRule.java
@@ -21,12 +21,11 @@ import com.google.common.base.Strings;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.betamax.*;
 
-import java.util.logging.Logger;
-
 import static com.google.common.base.CaseFormat.*;
-import static java.util.logging.Level.SEVERE;
 
 /**
  * This is an extension of {@link Recorder} that can be used as a
@@ -36,7 +35,7 @@ import static java.util.logging.Level.SEVERE;
  */
 public class RecorderRule extends Recorder implements TestRule {
 
-    private final Logger log = Logger.getLogger(RecorderRule.class.getName());
+    private final Logger log = LoggerFactory.getLogger(RecorderRule.class.getName());
 
     public RecorderRule() {
         super();
@@ -50,7 +49,7 @@ public class RecorderRule extends Recorder implements TestRule {
     public Statement apply(final Statement statement, final Description description) {
         final Betamax annotation = description.getAnnotation(Betamax.class);
         if (annotation != null) {
-            log.fine(String.format("found @Betamax annotation on '%s'", description.getDisplayName()));
+            log.debug(String.format("found @Betamax annotation on '%s'", description.getDisplayName()));
             return new Statement() {
                 @Override
                 public void evaluate() throws Throwable {
@@ -74,7 +73,7 @@ public class RecorderRule extends Recorder implements TestRule {
 
                         statement.evaluate();
                     } catch (Exception e) {
-                        log.log(SEVERE, "Caught exception starting Betamax", e);
+                        log.error("Caught exception starting Betamax", e);
                         throw e;
                     } finally {
                         stop();
@@ -82,7 +81,7 @@ public class RecorderRule extends Recorder implements TestRule {
                 }
             };
         } else {
-            log.fine(String.format("no @Betamax annotation on '%s'", description.getDisplayName()));
+            log.debug(String.format("no @Betamax annotation on '%s'", description.getDisplayName()));
             return statement;
         }
     }

--- a/betamax-tests/betamax-tests.gradle
+++ b/betamax-tests/betamax-tests.gradle
@@ -27,3 +27,7 @@ dependencies {
 
     testCompile "com.mashape.unirest:unirest-java:1.2.8", "org.apache.httpcomponents:httpasyncclient:4.0"
 }
+
+test {
+    testLogging.showStandardStreams = true
+}

--- a/betamax-tests/src/test/groovy/logging.properties
+++ b/betamax-tests/src/test/groovy/logging.properties
@@ -1,8 +1,0 @@
-handlers = java.util.logging.ConsoleHandler
-
-.level = ALL
-
-java.util.logging.ConsoleHandler.level = WARN
-java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-
-betamax.level = ALL

--- a/betamax-tests/src/test/resources/log4j2.xml
+++ b/betamax-tests/src/test/resources/log4j2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d [%p] [%t] %C{5} (%F:%L) - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+        <Logger name="software.betamax" level="INFO" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="org.littleshoot" level="ERROR" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/betamax.gradle
+++ b/betamax.gradle
@@ -7,23 +7,25 @@ allprojects {
         isSnapshot = version.endsWith("-SNAPSHOT")
 
         commonDependencies = [
-            cglib: dependencies.create("cglib:cglib-nodep:2.2.2"),
-            groovy: dependencies.create("org.codehaus.groovy:groovy-all:2.4.5:indy"),
-            guava: dependencies.create("com.google.guava:guava:18.0"),
-            httpBuilder: dependencies.create("org.codehaus.groovy.modules.http-builder:http-builder:0.6", {
-                exclude module: "groovy"
-                exclude module: "httpclient"
-            }),
-            httpClient: dependencies.create("org.apache.httpcomponents:httpclient:4.3.1"),
-            junit: dependencies.create("junit:junit:4.12"),
-            littleProxy: dependencies.create("org.littleshoot:littleproxy:1.1.0-beta2"),
-            netty: dependencies.create("io.netty:netty-all:4.0.35.Final"),
-            snakeYaml: dependencies.create("org.yaml:snakeyaml:1.16"),
-            spock: dependencies.create("org.spockframework:spock-core:1.0-groovy-2.4", {
-                exclude module: "groovy-all"
-                exclude module: "junit"
-            }),
-            tika: dependencies.create("org.apache.tika:tika-core:1.11")
+                cglib         : dependencies.create("cglib:cglib-nodep:2.2.2"),
+                groovy        : dependencies.create("org.codehaus.groovy:groovy-all:2.4.5:indy"),
+                guava         : dependencies.create("com.google.guava:guava:18.0"),
+                httpBuilder   : dependencies.create("org.codehaus.groovy.modules.http-builder:http-builder:0.6", {
+                    exclude module: "groovy"
+                    exclude module: "httpclient"
+                }),
+                httpClient    : dependencies.create("org.apache.httpcomponents:httpclient:4.3.1"),
+                junit         : dependencies.create("junit:junit:4.12"),
+                littleProxy   : dependencies.create("org.littleshoot:littleproxy:1.1.0-beta2"),
+                log4jCore     : dependencies.create("org.apache.logging.log4j:log4j-core:2.0.1"),
+                log4jSlf4jImpl: dependencies.create("org.apache.logging.log4j:log4j-slf4j-impl:2.0.1"),
+                netty         : dependencies.create("io.netty:netty-all:4.0.35.Final"),
+                snakeYaml     : dependencies.create("org.yaml:snakeyaml:1.16"),
+                spock         : dependencies.create("org.spockframework:spock-core:1.0-groovy-2.4", {
+                    exclude module: "groovy-all"
+                    exclude module: "junit"
+                }),
+                tika          : dependencies.create("org.apache.tika:tika-core:1.11")
         ]
     }
 }


### PR DESCRIPTION
This PR replaces `java.utils.logging` with the `slf4j` library.

The main reasoning behind this is: 
SLF4J grants the end-user the liberty to choose the underlying logging framework.

An in-depth discussion about JUL and SLF4J can be found [on StackOverflow](http://stackoverflow.com/questions/11359187/why-not-use-java-util-logging).